### PR TITLE
Parallelize verification within large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ $ caf verify
 
 Both commands take `--jobs` to spread their work over worker threads.
 Generation splits a single large file across threads, and verification
-splits the store across them.  The results are identical at any value, so
-it only changes how long the command takes:
+uses one global worker budget across the store: it validates files in
+parallel and lends spare workers to positional reads and corruption
+analysis within large files. The ordered whole-file BLAKE2b digest remains
+single-threaded per file. The results are identical at any value, so the
+setting only changes how long the command takes:
 
 ```
 $ caf gen --max-files 1 --file-size 4GB --jobs 8

--- a/crates/caf-format/src/content.rs
+++ b/crates/caf-format/src/content.rs
@@ -137,6 +137,66 @@ impl ContentReader {
         }
     }
 
+    /// Creates a content stream at the specified offset.
+    ///
+    /// The offset is content-relative: offset zero is the file byte at
+    /// [`HEADER_SIZE`], not the start of the header. Every `u64` offset
+    /// is supported without overflow. Locating it uses direct block
+    /// arithmetic, then discards at most one block's prefix; it never
+    /// advances through all preceding content.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::Read;
+    ///
+    /// use caf_format::{ContentReader, ContentSeed};
+    ///
+    /// let seed = ContentSeed::from_hex("b42d9a6630882f79c7599ae213435f86")?;
+    /// let offset = 1_100_000_u64;
+    /// let mut whole = vec![0_u8; offset as usize + 32];
+    /// ContentReader::new(seed).read_exact(&mut whole)?;
+    ///
+    /// let mut from_offset = [0_u8; 32];
+    /// ContentReader::new_with_offset(seed, offset).read_exact(&mut from_offset)?;
+    /// assert_eq!(from_offset, whole[offset as usize..]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[must_use]
+    pub fn new_with_offset(seed: ContentSeed, offset: u64) -> Self {
+        let first_len = block_len(0) as u64;
+        let (block_index, mut offset_in_block) = if offset < first_len {
+            (0, offset)
+        } else {
+            let after_first = offset - first_len;
+            (
+                1 + after_first / BLOCK_SIZE as u64,
+                after_first % BLOCK_SIZE as u64,
+            )
+        };
+
+        let mut reader = Self {
+            seed,
+            next_block_index: block_index,
+            block: None,
+            remaining_in_block: 0,
+        };
+        if offset_in_block != 0 {
+            let (block, _remaining) = reader.current_block();
+            let mut discard = [0_u8; 8192];
+            let mut discarded = 0_usize;
+            while offset_in_block > 0 {
+                let take_u64 = offset_in_block.min(8192);
+                let take = usize::try_from(take_u64).unwrap_or(discard.len());
+                XofReader::read(block, &mut discard[..take]);
+                discarded += take;
+                offset_in_block -= take_u64;
+            }
+            reader.remaining_in_block -= discarded;
+        }
+        reader
+    }
+
     /// Returns the seed this stream derives content from.
     #[must_use]
     pub fn seed(&self) -> ContentSeed {
@@ -204,6 +264,12 @@ mod tests {
 
     fn seed() -> ContentSeed {
         ContentSeed::from_bytes(*b"0123456789abcdef")
+    }
+
+    #[test]
+    fn content_reader_remains_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ContentReader>();
     }
 
     #[test]
@@ -281,5 +347,41 @@ mod tests {
             .read_to_end(&mut content)
             .unwrap();
         assert_eq!(content.len(), 1024);
+    }
+
+    #[test]
+    fn offset_reader_matches_a_slice_of_the_complete_stream() {
+        let first = block_len(0);
+        let offsets = [
+            0_u64,
+            1,
+            first as u64 - 1,
+            first as u64,
+            first as u64 + 1,
+            first as u64 + crate::BLOCK_SIZE as u64,
+            first as u64 + crate::BLOCK_SIZE as u64 + 17,
+        ];
+        let reference_len = usize::try_from(offsets.last().copied().unwrap()).unwrap() + 257;
+        let mut reference = vec![0_u8; reference_len];
+        ContentReader::new(seed())
+            .read_exact(&mut reference)
+            .unwrap();
+
+        for offset in offsets {
+            let mut actual = [0_u8; 257];
+            ContentReader::new_with_offset(seed(), offset)
+                .read_exact(&mut actual)
+                .unwrap();
+            let offset = usize::try_from(offset).unwrap();
+            assert_eq!(actual, reference[offset..offset + 257]);
+        }
+    }
+
+    #[test]
+    fn maximum_offset_is_supported_without_overflow() {
+        let mut actual = [0_u8; 1];
+        ContentReader::new_with_offset(seed(), u64::MAX)
+            .read_exact(&mut actual)
+            .unwrap();
     }
 }

--- a/crates/caf-format/src/lib.rs
+++ b/crates/caf-format/src/lib.rs
@@ -9,9 +9,9 @@
 //!   field, plus a raw diagnostic view ([`RawHeader`]) for tools that
 //!   display invalid headers.
 //! - The deterministic SHAKE-128 content stream ([`ContentReader`],
-//!   [`fill_block`], [`fill_block_prefix`]) with the [`CONTENT_DOMAIN`]
-//!   domain, the shortened block 0, and 1 MiB later blocks,
-//!   independently derivable per block index.
+//!   [`ContentReader::new_with_offset`], [`fill_block`], [`fill_block_prefix`])
+//!   with the [`CONTENT_DOMAIN`] domain, the shortened block 0, and 1 MiB
+//!   later blocks, independently derivable per block index.
 //! - Whole-file digest primitives and hash-to-path / path-to-hash
 //!   conversion ([`hash_to_relpath`], [`parse_hash_from_path`]) for the
 //!   `aa/bb/cc/<34-character basename>` layout.

--- a/crates/caf-store/benches/store.rs
+++ b/crates/caf-store/benches/store.rs
@@ -11,12 +11,13 @@
 //!   full-scale numbers come from `examples/verify.rs`.
 //! - `verify/1000x4KiB-jobsN`: the parallel pipeline over the
 //!   same store at several worker counts.
-//! - `verify/8x8MiB`: clean sequential verification byte throughput.
-//! - `verify/8x8MiB-jobsN` — parallel byte throughput (one worker per
-//!   file at most; the store has eight files).
-//! - `verify/corrupt-8MiB` — the corruption-analysis path (SHAKE
-//!   regeneration plus chunk comparison at the default 4,096-byte
-//!   analysis chunk size).
+//! - `verify/1x64MiB-jobsN`: one clean large file, exercising positional
+//!   readers feeding one ordered digest.
+//! - `verify/5x32MiB-jobsN`: spare-lane allocation across a small set of
+//!   equal large files.
+//! - `verify/corrupt-{start,middle,end}-32MiB-jobsN` — the
+//!   corruption-analysis path (SHAKE regeneration plus chunk comparison
+//!   at the default 4,096-byte analysis chunk size).
 //!
 //! Each generation iteration writes into a fresh temporary store on the
 //! same filesystem; teardown happens outside the timed section.
@@ -29,7 +30,7 @@
 )]
 
 use std::hint::black_box;
-use std::io::{Seek as _, SeekFrom, Write as _};
+use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::num::NonZeroUsize;
 
 use caf_store::{Generator, SizeChooser, SizeSpec, Verifier};
@@ -81,6 +82,7 @@ fn generation(c: &mut Criterion) {
 fn verification(c: &mut Criterion) {
     let mut group = c.benchmark_group("verify");
     group.sample_size(10);
+    let worker_counts = verification_worker_counts();
 
     let small = tempfile::tempdir().expect("create temp store");
     Generator::builder(small.path())
@@ -112,27 +114,18 @@ fn verification(c: &mut Criterion) {
         });
     }
 
-    let large = tempfile::tempdir().expect("create temp store");
-    Generator::builder(large.path())
-        .max_files(8)
-        .file_sizes(SizeChooser::fixed(8 * 1024 * 1024))
+    let one_large = tempfile::tempdir().expect("create temp store");
+    Generator::builder(one_large.path())
+        .max_files(1)
+        .file_sizes(SizeChooser::fixed(64 * 1024 * 1024))
         .build()
         .generate()
         .expect("generation succeeds");
-    group.throughput(Throughput::Bytes(8 * 8 * 1024 * 1024));
-    group.bench_function("8x8MiB", |b| {
-        b.iter(|| {
-            let report = Verifier::new(large.path())
-                .verify()
-                .expect("verification runs");
-            assert!(report.success());
-            black_box(report)
-        });
-    });
-    for jobs in [2, 4] {
-        group.bench_function(format!("8x8MiB-jobs{jobs}"), |b| {
+    group.throughput(Throughput::Bytes(64 * 1024 * 1024));
+    for &jobs in &worker_counts {
+        group.bench_function(format!("1x64MiB-jobs{jobs}"), |b| {
             b.iter(|| {
-                let report = Verifier::new(large.path())
+                let report = Verifier::new(one_large.path())
                     .jobs(NonZeroUsize::new(jobs).expect("the bench worker counts are positive"))
                     .verify()
                     .expect("verification runs");
@@ -142,34 +135,68 @@ fn verification(c: &mut Criterion) {
         });
     }
 
-    // One 8 MiB file with a corrupted byte in every megabyte: measures
-    // the analysis path (full SHAKE regeneration plus chunked
-    // comparison) at the default 4,096-byte analysis chunk size.
-    let corrupt = tempfile::tempdir().expect("create temp store");
-    Generator::builder(corrupt.path())
-        .max_files(1)
-        .file_sizes(SizeChooser::fixed(8 * 1024 * 1024))
+    let five_large = tempfile::tempdir().expect("create temp store");
+    Generator::builder(five_large.path())
+        .max_files(5)
+        .file_sizes(SizeChooser::fixed(32 * 1024 * 1024))
         .build()
         .generate()
         .expect("generation succeeds");
-    corrupt_every_mebibyte(corrupt.path());
-    group.throughput(Throughput::Bytes(8 * 1024 * 1024));
-    group.bench_function("corrupt-8MiB", |b| {
-        b.iter(|| {
-            let report = Verifier::new(corrupt.path())
-                .verify()
-                .expect("verification runs");
-            assert!(!report.success());
-            black_box(report)
+    group.throughput(Throughput::Bytes(5 * 32 * 1024 * 1024));
+    for &jobs in &worker_counts {
+        group.bench_function(format!("5x32MiB-jobs{jobs}"), |b| {
+            b.iter(|| {
+                let report = Verifier::new(five_large.path())
+                    .jobs(NonZeroUsize::new(jobs).expect("the bench worker counts are positive"))
+                    .verify()
+                    .expect("verification runs");
+                assert!(report.success());
+                black_box(report)
+            });
         });
-    });
+    }
+
+    // Damage near the start, middle, and end all trigger a full digest
+    // followed by expected-content regeneration. Keeping them separate
+    // catches any accidental dependence on the mismatch's position.
+    group.throughput(Throughput::Bytes(32 * 1024 * 1024));
+    for (position, offset) in [
+        ("start", 512 * 1024_u64),
+        ("middle", 16 * 1024 * 1024_u64),
+        ("end", 32 * 1024 * 1024_u64 - 512 * 1024),
+    ] {
+        let corrupt = corrupted_store(offset);
+        for &jobs in &worker_counts {
+            group.bench_function(format!("corrupt-{position}-32MiB-jobs{jobs}"), |b| {
+                b.iter(|| {
+                    let report = Verifier::new(corrupt.path())
+                        .jobs(
+                            NonZeroUsize::new(jobs).expect("the bench worker counts are positive"),
+                        )
+                        .verify()
+                        .expect("verification runs");
+                    assert!(!report.success());
+                    black_box(report)
+                });
+            });
+        }
+    }
 
     group.finish();
 }
 
-/// Flips one byte at every 1 MiB boundary (offset by half a block so
-/// block 0's shortened length does not matter) of the store's only file.
-fn corrupt_every_mebibyte(store: &std::path::Path) {
+fn verification_worker_counts() -> Vec<usize> {
+    let mut counts = vec![1, 2, 4, 8, 16];
+    if let Ok(logical) = std::thread::available_parallelism() {
+        counts.push(logical.get().min(caf_store::MAX_JOBS.get()));
+    }
+    counts.sort_unstable();
+    counts.dedup();
+    counts
+}
+
+/// Builds a 32 MiB one-file store and flips one byte at `offset`.
+fn corrupted_store(offset: u64) -> tempfile::TempDir {
     fn find_file(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
         for entry in std::fs::read_dir(dir).expect("store directories are readable") {
             let path = entry.expect("directory entries are readable").path();
@@ -183,20 +210,31 @@ fn corrupt_every_mebibyte(store: &std::path::Path) {
             }
         }
     }
+
+    let store = tempfile::tempdir().expect("create temp store");
+    Generator::builder(store.path())
+        .max_files(1)
+        .file_sizes(SizeChooser::fixed(32 * 1024 * 1024))
+        .build()
+        .generate()
+        .expect("generation succeeds");
     let mut files = Vec::new();
-    find_file(store, &mut files);
+    find_file(store.path(), &mut files);
     let [path] = &*files else {
         panic!("expected exactly one data file");
     };
     let mut file = std::fs::OpenOptions::new()
+        .read(true)
         .write(true)
         .open(path)
         .expect("data files are writable");
-    for mib in 0..8_u64 {
-        file.seek(SeekFrom::Start(mib * 1024 * 1024 + 512 * 1024))
-            .expect("seek succeeds");
-        file.write_all(&[0xFF]).expect("write succeeds");
-    }
+    file.seek(SeekFrom::Start(offset)).expect("seek succeeds");
+    let mut byte = [0_u8];
+    file.read_exact(&mut byte).expect("the byte is readable");
+    byte[0] ^= 0xFF;
+    file.seek(SeekFrom::Start(offset)).expect("seek succeeds");
+    file.write_all(&byte).expect("write succeeds");
+    store
 }
 
 fn size_selection(c: &mut Criterion) {

--- a/crates/caf-store/src/analysis.rs
+++ b/crates/caf-store/src/analysis.rs
@@ -10,9 +10,15 @@
 
 use std::io::{self, Read, Seek, SeekFrom};
 use std::num::NonZeroUsize;
+use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, SyncSender};
+use std::sync::{Condvar, Mutex, MutexGuard, PoisonError};
+use std::thread;
 
 use caf_format::{ContentReader, ContentSeed, Digest, HEADER_SIZE, Header};
+
+use crate::env::FileHandle;
 
 /// A chunk is `sparse` when fewer than this fraction of its bytes differ.
 const SPARSE_RATE: f64 = 0.1;
@@ -20,6 +26,77 @@ const SPARSE_RATE: f64 = 0.1;
 const ALIGNMENT_BOUNDARIES: [usize; 4] = [512, 1024, 4096, 8192];
 /// Only the first this-many differing positions are alignment-checked.
 const ALIGNMENT_POSITIONS: usize = 5;
+/// Target bytes compared by one independently scheduled task.
+const ANALYSIS_TASK_BYTES: usize = 8 * 1024 * 1024;
+/// Aggregate actual-plus-expected task buffers allowed per verification.
+const ANALYSIS_MEMORY_BYTES: usize = 256 * 1024 * 1024;
+
+/// Shared task-buffer budget for one verification run.
+#[derive(Debug)]
+pub(crate) struct AnalysisMemory {
+    used: Mutex<usize>,
+    available: Condvar,
+    limit: usize,
+}
+
+impl AnalysisMemory {
+    pub(crate) fn new() -> Self {
+        Self::with_limit(ANALYSIS_MEMORY_BYTES)
+    }
+
+    fn with_limit(limit: usize) -> Self {
+        Self {
+            used: Mutex::new(0),
+            available: Condvar::new(),
+            limit,
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, usize> {
+        self.used.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Reserves actual-plus-expected bytes before either task buffer is
+    /// allocated. A panic aborts blocked sibling tasks; an I/O error only
+    /// stops new claims, so already-claimed lower-offset tasks still run
+    /// and can supply the deterministic first error.
+    fn acquire<'memory>(
+        &'memory self,
+        bytes: usize,
+        gate: &AnalysisGate,
+    ) -> Option<AnalysisMemoryPermit<'memory>> {
+        debug_assert!(bytes <= self.limit, "one task fits the analysis budget");
+        let mut used = self.lock();
+        loop {
+            if gate.aborted() {
+                return None;
+            }
+            if bytes <= self.limit - *used {
+                *used += bytes;
+                return Some(AnalysisMemoryPermit {
+                    memory: self,
+                    bytes,
+                });
+            }
+            used = self
+                .available
+                .wait(used)
+                .unwrap_or_else(PoisonError::into_inner);
+        }
+    }
+}
+
+struct AnalysisMemoryPermit<'memory> {
+    memory: &'memory AnalysisMemory,
+    bytes: usize,
+}
+
+impl Drop for AnalysisMemoryPermit<'_> {
+    fn drop(&mut self) {
+        *self.memory.lock() -= self.bytes;
+        self.memory.available.notify_all();
+    }
+}
 
 /// The kind of corruption observed in one region of a file.
 ///
@@ -311,29 +388,425 @@ pub(crate) fn analyze(
         remaining -= got as u64;
     }
 
-    if actual_size < expected_size {
-        let missing_bytes = expected_size - actual_size;
-        push_region(
-            &mut regions,
-            CorruptionRegion::new(
-                actual_size,
-                missing_bytes,
-                CorruptionPattern::Truncated { missing_bytes },
-            ),
-        );
-    } else if actual_size > expected_size {
-        let extra_count = actual_size - expected_size;
-        push_region(
-            &mut regions,
-            CorruptionRegion::new(
-                expected_size,
-                extra_count,
-                CorruptionPattern::ExtraBytes { extra_count },
-            ),
-        );
-    }
+    append_size_region(&mut regions, actual_size, expected_size);
 
     Ok(regions)
+}
+
+/// Positional, parallel corruption analysis for one file group.
+///
+/// Tasks begin on exact analysis-chunk boundaries measured from the
+/// first content byte. Results are merged by task index, so task and I/O
+/// completion order cannot affect region classification or ordering.
+/// `width` is the whole file-group width; the calling coordinator also
+/// executes tasks, keeping total live threads within it.
+pub(crate) fn analyze_parallel(
+    source: &FileHandle,
+    header: &Header,
+    actual_size: u64,
+    chunk_size: NonZeroUsize,
+    width: usize,
+    memory: &AnalysisMemory,
+) -> io::Result<Vec<CorruptionRegion>> {
+    let expected_size = header.file_length();
+    let compare_end = actual_size.min(expected_size);
+    let compare_len = compare_end.saturating_sub(HEADER_SIZE as u64);
+    if compare_len == 0 {
+        let mut regions = Vec::new();
+        append_size_region(&mut regions, actual_size, expected_size);
+        return Ok(regions);
+    }
+
+    let chunks_per_task = (ANALYSIS_TASK_BYTES / chunk_size.get()).max(1);
+    let task_len = chunks_per_task
+        .checked_mul(chunk_size.get())
+        .expect("analysis chunks are clamped to 64 MiB");
+    let total_tasks = compare_len.div_ceil(task_len as u64);
+    let lanes = analysis_lane_count(width, task_len, total_tasks);
+    debug_assert!(lanes > 0, "parallel analysis has content and spare lanes");
+
+    let plan = AnalysisPlan {
+        source,
+        seed: header.content_seed(),
+        compare_len,
+        chunk_size: chunk_size.get(),
+        task_len,
+        total_tasks,
+        lanes,
+    };
+    let mut collection = run_parallel_analysis(&plan, memory);
+    debug_assert!(
+        collection.failure.is_some()
+            || collection.panic_payload.is_some()
+            || collection.next_result == total_tasks,
+        "every successful analysis task is collected"
+    );
+    if let Some(payload) = collection.panic_payload {
+        panic::resume_unwind(payload);
+    }
+    if let Some((_index, source)) = collection.failure {
+        return Err(source);
+    }
+
+    append_size_region(&mut collection.regions, actual_size, expected_size);
+    Ok(collection.regions)
+}
+
+fn analysis_lane_count(width: usize, task_len: usize, total_tasks: u64) -> usize {
+    debug_assert!(task_len > 0, "an analysis task contains at least one chunk");
+    debug_assert!(total_tasks > 0, "analysis lanes require content to compare");
+    let memory_lanes = (ANALYSIS_MEMORY_BYTES / task_len.saturating_mul(2)).max(1);
+    width
+        .min(memory_lanes)
+        .min(usize::try_from(total_tasks).unwrap_or(usize::MAX))
+}
+
+#[derive(Clone, Copy)]
+struct AnalysisPlan<'file> {
+    source: &'file FileHandle,
+    seed: ContentSeed,
+    compare_len: u64,
+    chunk_size: usize,
+    task_len: usize,
+    total_tasks: u64,
+    lanes: usize,
+}
+
+fn run_parallel_analysis(plan: &AnalysisPlan<'_>, memory: &AnalysisMemory) -> AnalysisCollection {
+    let window = plan.lanes.saturating_mul(4);
+    let gate = AnalysisGate::new();
+    let (sender, receiver) = mpsc::sync_channel(window);
+
+    thread::scope(|scope| {
+        // The coordinator below is one analysis lane. Every additional
+        // lane runs the same claim loop on a scoped worker thread.
+        for _ in 1..plan.lanes {
+            let sender = sender.clone();
+            let gate = &gate;
+            scope.spawn(move || {
+                let worked = panic::catch_unwind(AssertUnwindSafe(|| {
+                    analyze_tasks(plan, gate, window, memory, &sender);
+                }));
+                if let Err(payload) = worked {
+                    gate.abort(memory);
+                    let _ignored = sender.send(AnalysisMessage::Panic(payload));
+                }
+            });
+        }
+        drop(sender);
+
+        let mut collection = AnalysisCollection::new();
+        let worked = panic::catch_unwind(AssertUnwindSafe(|| {
+            loop {
+                while let Ok(message) = receiver.try_recv() {
+                    collection.absorb(message);
+                    gate.collected_through(collection.next_result);
+                }
+
+                let index = match gate.try_claim(plan.total_tasks, window) {
+                    AnalysisClaim::Index(index) => index,
+                    AnalysisClaim::Blocked => {
+                        // Receiving while blocked lets the missing early
+                        // result advance the claim window without
+                        // deadlocking behind a full result channel.
+                        match receiver.recv() {
+                            Ok(message) => {
+                                collection.absorb(message);
+                                gate.collected_through(collection.next_result);
+                            }
+                            Err(_disconnected) => break,
+                        }
+                        continue;
+                    }
+                    AnalysisClaim::Stopped => break,
+                };
+                let Some(result) = analyze_task(plan, index, memory, &gate) else {
+                    break;
+                };
+                if result.is_err() {
+                    gate.stop();
+                }
+                collection.absorb(AnalysisMessage::Task { index, result });
+                gate.collected_through(collection.next_result);
+            }
+        }));
+        if let Err(payload) = worked {
+            gate.abort(memory);
+            collection.absorb(AnalysisMessage::Panic(payload));
+        }
+
+        // Worker senders close after all siblings observe exhaustion or
+        // cancellation. Drain every in-flight result before the scope
+        // joins and before a panic is resumed.
+        for message in receiver {
+            collection.absorb(message);
+            gate.collected_through(collection.next_result);
+        }
+        collection
+    })
+}
+
+fn analyze_tasks(
+    plan: &AnalysisPlan<'_>,
+    gate: &AnalysisGate,
+    window: usize,
+    memory: &AnalysisMemory,
+    sender: &SyncSender<AnalysisMessage>,
+) {
+    while let Some(index) = gate.claim(plan.total_tasks, window) {
+        let Some(result) = analyze_task(plan, index, memory, gate) else {
+            return;
+        };
+        if result.is_err() {
+            gate.stop();
+        }
+        if sender
+            .send(AnalysisMessage::Task { index, result })
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+/// Hands out analysis tasks no farther than the bounded reorder window
+/// ahead of the lowest result not yet collected.
+struct AnalysisGate {
+    state: Mutex<AnalysisGateState>,
+    changed: Condvar,
+}
+
+struct AnalysisGateState {
+    next_claim: u64,
+    collected: u64,
+    stopped: bool,
+    aborted: bool,
+}
+
+enum AnalysisClaim {
+    Index(u64),
+    Blocked,
+    Stopped,
+}
+
+impl AnalysisGate {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(AnalysisGateState {
+                next_claim: 0,
+                collected: 0,
+                stopped: false,
+                aborted: false,
+            }),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, AnalysisGateState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Nonblocking claim for the coordinator, which must remain able to
+    /// drain the result channel when the ordered window is full.
+    fn try_claim(&self, total: u64, window: usize) -> AnalysisClaim {
+        let mut state = self.lock();
+        if state.stopped || state.next_claim >= total {
+            return AnalysisClaim::Stopped;
+        }
+        let limit = state
+            .collected
+            .saturating_add(u64::try_from(window).unwrap_or(u64::MAX));
+        if state.next_claim >= limit {
+            return AnalysisClaim::Blocked;
+        }
+        let index = state.next_claim;
+        state.next_claim += 1;
+        AnalysisClaim::Index(index)
+    }
+
+    /// Blocking worker claim. Cancellation and ordered collection both
+    /// wake waiters, so errors and panics cannot strand sibling lanes.
+    fn claim(&self, total: u64, window: usize) -> Option<u64> {
+        let mut state = self.lock();
+        loop {
+            if state.stopped || state.next_claim >= total {
+                return None;
+            }
+            let limit = state
+                .collected
+                .saturating_add(u64::try_from(window).unwrap_or(u64::MAX));
+            if state.next_claim < limit {
+                let index = state.next_claim;
+                state.next_claim += 1;
+                return Some(index);
+            }
+            state = self
+                .changed
+                .wait(state)
+                .unwrap_or_else(PoisonError::into_inner);
+        }
+    }
+
+    fn collected_through(&self, next_result: u64) {
+        let mut state = self.lock();
+        if next_result > state.collected {
+            state.collected = next_result;
+            drop(state);
+            self.changed.notify_all();
+        }
+    }
+
+    fn stop(&self) {
+        self.lock().stopped = true;
+        self.changed.notify_all();
+    }
+
+    fn aborted(&self) -> bool {
+        self.lock().aborted
+    }
+
+    /// Stops new claims and wakes tasks blocked on the shared memory
+    /// budget. Taking the memory lock before the gate lock matches
+    /// `AnalysisMemory::acquire`, preventing a cancellation wakeup from
+    /// being lost between its abort check and condition-variable wait.
+    fn abort(&self, memory: &AnalysisMemory) {
+        let _memory = memory.lock();
+        let mut state = self.lock();
+        state.stopped = true;
+        state.aborted = true;
+        drop(state);
+        self.changed.notify_all();
+        memory.available.notify_all();
+    }
+}
+
+fn analyze_task(
+    plan: &AnalysisPlan<'_>,
+    index: u64,
+    memory: &AnalysisMemory,
+    gate: &AnalysisGate,
+) -> Option<io::Result<Vec<CorruptionRegion>>> {
+    let content_offset = index * plan.task_len as u64;
+    let len = usize::try_from((plan.compare_len - content_offset).min(plan.task_len as u64))
+        .expect("a task is bounded by task_len");
+    let _memory = memory.acquire(len.saturating_mul(2), gate)?;
+    Some((|| {
+        let file_offset = HEADER_SIZE as u64 + content_offset;
+        let mut actual = vec![0_u8; len];
+        let got = plan.source.read_full_at(&mut actual, file_offset)?;
+        actual.truncate(got);
+        let mut expected = vec![0_u8; got];
+        ContentReader::new_with_offset(plan.seed, content_offset)
+            .read_exact(&mut expected)
+            .expect("the content stream is infinite and never fails");
+
+        let mut regions = Vec::new();
+        for (chunk_index, (actual, expected)) in actual
+            .chunks(plan.chunk_size)
+            .zip(expected.chunks(plan.chunk_size))
+            .enumerate()
+        {
+            if actual != expected {
+                let relative = chunk_index * plan.chunk_size;
+                push_region(
+                    &mut regions,
+                    CorruptionRegion::new(
+                        file_offset + relative as u64,
+                        actual.len() as u64,
+                        classify_chunk(actual, expected),
+                    ),
+                );
+            }
+        }
+        Ok(regions)
+    })())
+}
+
+enum AnalysisMessage {
+    Task {
+        index: u64,
+        result: io::Result<Vec<CorruptionRegion>>,
+    },
+    Panic(Box<dyn std::any::Any + Send>),
+}
+
+/// Ordered, bounded fold of analysis task messages.
+struct AnalysisCollection {
+    pending: std::collections::BTreeMap<u64, Vec<CorruptionRegion>>,
+    next_result: u64,
+    regions: Vec<CorruptionRegion>,
+    failure: Option<(u64, io::Error)>,
+    panic_payload: Option<Box<dyn std::any::Any + Send>>,
+}
+
+impl AnalysisCollection {
+    fn new() -> Self {
+        Self {
+            pending: std::collections::BTreeMap::new(),
+            next_result: 0,
+            regions: Vec::new(),
+            failure: None,
+            panic_payload: None,
+        }
+    }
+
+    fn absorb(&mut self, message: AnalysisMessage) {
+        match message {
+            AnalysisMessage::Task { index, result } => match result {
+                Ok(task_regions) => {
+                    self.pending.insert(index, task_regions);
+                    while let Some(task_regions) = self.pending.remove(&self.next_result) {
+                        for region in task_regions {
+                            push_region(&mut self.regions, region);
+                        }
+                        self.next_result += 1;
+                    }
+                }
+                Err(source) => {
+                    if self
+                        .failure
+                        .as_ref()
+                        .is_none_or(|(recorded, _source)| index < *recorded)
+                    {
+                        self.failure = Some((index, source));
+                    }
+                }
+            },
+            AnalysisMessage::Panic(payload) => {
+                if self.panic_payload.is_none() {
+                    self.panic_payload = Some(payload);
+                }
+            }
+        }
+    }
+}
+
+fn append_size_region(regions: &mut Vec<CorruptionRegion>, actual_size: u64, expected_size: u64) {
+    match actual_size.cmp(&expected_size) {
+        std::cmp::Ordering::Less => {
+            let missing_bytes = expected_size - actual_size;
+            push_region(
+                regions,
+                CorruptionRegion::new(
+                    actual_size,
+                    missing_bytes,
+                    CorruptionPattern::Truncated { missing_bytes },
+                ),
+            );
+        }
+        std::cmp::Ordering::Greater => {
+            let extra_count = actual_size - expected_size;
+            push_region(
+                regions,
+                CorruptionRegion::new(
+                    expected_size,
+                    extra_count,
+                    CorruptionPattern::ExtraBytes { extra_count },
+                ),
+            );
+        }
+        std::cmp::Ordering::Equal => {}
+    }
 }
 
 /// Appends `region`, merging it into the previous region when they are
@@ -430,11 +903,15 @@ pub(crate) fn read_full(mut source: impl Read, buf: &mut [u8]) -> io::Result<usi
 mod tests {
     use std::io::{Cursor, Read as _, Write as _};
     use std::num::NonZeroUsize;
+    use std::sync::{Barrier, mpsc};
+    use std::thread;
+    use std::time::Duration;
 
     use caf_format::{ContentReader, ContentSeed, Digest, HEADER_SIZE, Header};
 
     use super::{
-        CorruptionClass, CorruptionPattern, CorruptionRegion, CorruptionReport, analyze,
+        ANALYSIS_MEMORY_BYTES, AnalysisClaim, AnalysisGate, AnalysisMemory, CorruptionClass,
+        CorruptionPattern, CorruptionRegion, CorruptionReport, analysis_lane_count, analyze,
         check_alignment, classify_chunk, push_region,
     };
 
@@ -469,6 +946,86 @@ mod tests {
     fn clean_content_yields_no_regions() {
         let bytes = clean_file(4096);
         assert_eq!(regions_of(&bytes, 256), Vec::new());
+    }
+
+    #[test]
+    fn analysis_lanes_honor_the_actual_plus_expected_memory_limit() {
+        let mib = 1024 * 1024;
+        assert_eq!(analysis_lane_count(256, 64 * mib, 100), 2);
+        assert_eq!(analysis_lane_count(256, 8 * mib, 100), 16);
+        assert_eq!(analysis_lane_count(256, ANALYSIS_MEMORY_BYTES, 100), 1);
+        assert_eq!(analysis_lane_count(256, 8 * mib, 3), 3);
+    }
+
+    #[test]
+    fn analysis_memory_is_shared_and_released_across_groups() {
+        let memory = AnalysisMemory::with_limit(10);
+        let first_gate = AnalysisGate::new();
+        let second_gate = AnalysisGate::new();
+        let first = memory.acquire(8, &first_gate).expect("first permit");
+        let barrier = Barrier::new(2);
+        let (sender, receiver) = mpsc::channel();
+
+        thread::scope(|scope| {
+            scope.spawn(|| {
+                barrier.wait();
+                let second = memory.acquire(8, &second_gate).expect("second permit");
+                sender.send(()).expect("the test receiver remains");
+                drop(second);
+            });
+            barrier.wait();
+            assert_eq!(*memory.lock(), 8);
+            assert!(receiver.try_recv().is_err());
+            drop(first);
+            receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("releasing the first group wakes the second");
+        });
+        assert_eq!(*memory.lock(), 0);
+    }
+
+    #[test]
+    fn analysis_memory_waiters_wake_when_their_group_aborts() {
+        let memory = AnalysisMemory::with_limit(10);
+        let occupying_gate = AnalysisGate::new();
+        let blocked_gate = AnalysisGate::new();
+        let occupying = memory
+            .acquire(10, &occupying_gate)
+            .expect("occupying permit");
+        let barrier = Barrier::new(2);
+        let (sender, receiver) = mpsc::channel();
+
+        thread::scope(|scope| {
+            scope.spawn(|| {
+                barrier.wait();
+                sender
+                    .send(memory.acquire(8, &blocked_gate).is_none())
+                    .expect("the test receiver remains");
+            });
+            barrier.wait();
+            blocked_gate.abort(&memory);
+            assert!(
+                receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("abort wakes the blocked task")
+            );
+        });
+        drop(occupying);
+        assert_eq!(*memory.lock(), 0);
+    }
+
+    #[test]
+    fn analysis_claims_stay_within_the_ordered_window() {
+        let gate = AnalysisGate::new();
+        for expected in 0..8 {
+            let AnalysisClaim::Index(actual) = gate.try_claim(100, 8) else {
+                panic!("index {expected} should be claimable");
+            };
+            assert_eq!(actual, expected);
+        }
+        assert!(matches!(gate.try_claim(100, 8), AnalysisClaim::Blocked));
+        gate.collected_through(1);
+        assert!(matches!(gate.try_claim(100, 8), AnalysisClaim::Index(8)));
     }
 
     #[test]
@@ -685,5 +1242,109 @@ mod tests {
         assert_eq!(report.class(), CorruptionClass::Content);
         // Percentage uses the larger of the two sizes.
         assert!((report.corruption_percentage() - 50.0).abs() < 1e-9);
+    }
+}
+
+#[cfg(all(test, feature = "test-util"))]
+mod mocked_parallel_tests {
+    use std::io::{self, Cursor, Read as _};
+    use std::num::NonZeroUsize;
+    use std::panic::{self, AssertUnwindSafe};
+    use std::path::Path;
+    use std::time::Duration;
+
+    use caf_format::{ContentReader, ContentSeed, Digest, HEADER_SIZE, Header};
+
+    use super::{ANALYSIS_TASK_BYTES, AnalysisMemory, analyze, analyze_parallel};
+    use crate::env::Env;
+
+    fn fixture(content_len: usize) -> (Header, Vec<u8>) {
+        let seed = ContentSeed::from_bytes(*b"parallel-analyze");
+        let file_len = HEADER_SIZE as u64 + content_len as u64;
+        let header = Header::new(Digest::ZERO, seed, file_len).expect("the fixture size is valid");
+        let mut bytes = header.encode().to_vec();
+        let mut content = vec![0_u8; content_len];
+        ContentReader::new(seed)
+            .read_exact(&mut content)
+            .expect("expected content is infinite");
+        bytes.extend_from_slice(&content);
+        (header, bytes)
+    }
+
+    fn chunk_size() -> NonZeroUsize {
+        NonZeroUsize::new(4096).expect("the chunk size is positive")
+    }
+
+    #[test]
+    fn parallel_analysis_retries_and_reorders_positional_reads() {
+        let (header, mut bytes) = fixture(2 * ANALYSIS_TASK_BYTES + 1234);
+        bytes[HEADER_SIZE + 17] ^= 0xFF;
+        bytes[HEADER_SIZE + ANALYSIS_TASK_BYTES + 29] ^= 0xFF;
+        let expected = analyze(
+            Cursor::new(&bytes),
+            &header,
+            bytes.len() as u64,
+            chunk_size(),
+        )
+        .expect("serial analysis succeeds");
+
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", bytes.clone())
+            .expect("the fixture is writable");
+        ctrl.delay_read_at(HEADER_SIZE as u64 + 1, Duration::from_millis(30));
+        ctrl.interrupt_next_read_at();
+        ctrl.limit_next_read_at(17);
+        let file = env.open(Path::new("/file")).expect("the file opens");
+
+        let actual = analyze_parallel(
+            &file,
+            &header,
+            bytes.len() as u64,
+            chunk_size(),
+            4,
+            &AnalysisMemory::new(),
+        )
+        .expect("parallel analysis retries and succeeds");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn parallel_analysis_returns_the_lowest_offset_error() {
+        let (header, bytes) = fixture(2 * ANALYSIS_TASK_BYTES + 1234);
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", bytes.clone())
+            .expect("the fixture is writable");
+        ctrl.delay_read_at(HEADER_SIZE as u64 + 1, Duration::from_millis(30));
+        ctrl.fail_read_at(HEADER_SIZE as u64 + 100, io::ErrorKind::PermissionDenied);
+        ctrl.fail_read_at(
+            HEADER_SIZE as u64 + ANALYSIS_TASK_BYTES as u64 + 100,
+            io::ErrorKind::StorageFull,
+        );
+        let file = env.open(Path::new("/file")).expect("the file opens");
+        let memory = AnalysisMemory::with_limit(2 * ANALYSIS_TASK_BYTES);
+
+        let error = analyze_parallel(&file, &header, bytes.len() as u64, chunk_size(), 3, &memory)
+            .expect_err("both initial analysis tasks fail");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn parallel_analysis_propagates_a_worker_panic() {
+        let (header, bytes) = fixture(2 * ANALYSIS_TASK_BYTES + 1234);
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", bytes.clone())
+            .expect("the fixture is writable");
+        ctrl.panic_read_at(HEADER_SIZE as u64 + ANALYSIS_TASK_BYTES as u64 + 100);
+        let file = env.open(Path::new("/file")).expect("the file opens");
+        let memory = AnalysisMemory::with_limit(2 * ANALYSIS_TASK_BYTES);
+
+        let payload = panic::catch_unwind(AssertUnwindSafe(|| {
+            analyze_parallel(&file, &header, bytes.len() as u64, chunk_size(), 3, &memory)
+        }))
+        .expect_err("the worker panic reaches the coordinator");
+        assert_eq!(
+            payload.downcast_ref::<&str>(),
+            Some(&"the mocked positional read panicked")
+        );
     }
 }

--- a/crates/caf-store/src/env.rs
+++ b/crates/caf-store/src/env.rs
@@ -11,10 +11,11 @@
 //! The abstraction is deliberately thin — one method per syscall the
 //! crate makes, with `std` types in the signatures — so the native path
 //! stays a direct call. [`FileHandle`] carries the positional
-//! ([`write_all_at`](FileHandle::write_all_at)) and preallocating
-//! ([`set_len`](FileHandle::set_len)) operations parallel generation
-//! needs alongside the cursor-based [`Read`]/[`Write`] impls the
-//! sequential paths use.
+//! ([`read_full_at`](FileHandle::read_full_at),
+//! [`write_all_at`](FileHandle::write_all_at)) and preallocating
+//! ([`set_len`](FileHandle::set_len)) operations parallel generation and
+//! verification need alongside the cursor-based [`Read`]/[`Write`] impls
+//! the sequential paths use.
 
 #[cfg(feature = "test-util")]
 pub(crate) mod mock;
@@ -299,6 +300,46 @@ impl FileHandle {
         }
     }
 
+    /// Reads once into `buf` at `offset`, independently of the file
+    /// cursor. The read may be short and returns zero at end-of-file.
+    /// Windows implements this with `seek_read`, which can move the
+    /// handle's cursor as a side effect, so callers must not overlap
+    /// positional reads with cursor-based I/O on the same handle.
+    pub(crate) fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        match self {
+            #[cfg(unix)]
+            Self::Native(file) => std::os::unix::fs::FileExt::read_at(file, buf, offset),
+            #[cfg(windows)]
+            Self::Native(file) => std::os::windows::fs::FileExt::seek_read(file, buf, offset),
+            #[cfg(feature = "test-util")]
+            Self::Mocked(file) => file.read_at(buf, offset),
+        }
+    }
+
+    /// Reads into `buf` at `offset` until it is full or EOF is reached.
+    ///
+    /// Interrupted reads are retried and short reads advance both the
+    /// buffer and file offset. A zero-byte read stops immediately, so an
+    /// unexpected EOF cannot spin.
+    pub(crate) fn read_full_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let mut filled = 0;
+        while filled < buf.len() {
+            let at = offset.checked_add(filled as u64).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "positional read offset overflow",
+                )
+            })?;
+            match self.read_at(&mut buf[filled..], at) {
+                Ok(0) => break,
+                Ok(count) => filled += count,
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(filled)
+    }
+
     /// Writes all of `buf` at `offset`, independent of the file cursor.
     ///
     /// The offset travels with each call and no shared cursor moves, so
@@ -388,10 +429,56 @@ impl Seek for FileHandle {
 
 #[cfg(all(test, feature = "test-util"))]
 mod tests {
-    use std::io;
+    use std::io::{self, Read as _};
     use std::num::NonZeroUsize;
+    use std::path::Path;
 
+    use super::Env;
     use crate::{Generator, SizeChooser};
+
+    #[test]
+    fn mocked_positional_reads_retry_and_do_not_move_the_cursor() {
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", b"0123456789".to_vec())
+            .expect("the fixture is writable");
+        let mut file = env.open(Path::new("/file")).expect("the file opens");
+
+        let mut cursor_prefix = [0_u8; 2];
+        file.read_exact(&mut cursor_prefix).expect("cursor read");
+        assert_eq!(&cursor_prefix, b"01");
+
+        ctrl.interrupt_next_read_at();
+        ctrl.limit_next_read_at(2);
+        let mut positional = [0_u8; 6];
+        let got = file
+            .read_full_at(&mut positional, 3)
+            .expect("interrupted and short reads are retried");
+        assert_eq!(got, positional.len());
+        assert_eq!(&positional, b"345678");
+
+        let mut cursor_suffix = [0_u8; 2];
+        file.read_exact(&mut cursor_suffix)
+            .expect("cursor remains at 2");
+        assert_eq!(&cursor_suffix, b"23");
+    }
+
+    #[test]
+    fn mocked_positional_read_stops_on_eof_and_injects_offset_failures() {
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", b"abcdef".to_vec())
+            .expect("the fixture is writable");
+        let file = env.open(Path::new("/file")).expect("the file opens");
+
+        let mut tail = [0_u8; 8];
+        assert_eq!(file.read_full_at(&mut tail, 4).expect("read to EOF"), 2);
+        assert_eq!(&tail[..2], b"ef");
+
+        ctrl.fail_read_at(3, io::ErrorKind::PermissionDenied);
+        let error = file
+            .read_full_at(&mut tail, 0)
+            .expect_err("the requested range covers the failed offset");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
 
     /// The point of the dispatch: a full generate-then-verify round trip
     /// with no syscall behind it, serially and on the worker pipeline.

--- a/crates/caf-store/src/env/mock.rs
+++ b/crates/caf-store/src/env/mock.rs
@@ -8,10 +8,11 @@
 //! modeled; nothing in generation or verification depends on them beyond
 //! the symlink rules of the walk, which a mocked store never exercises.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::Duration;
 
 use super::{DirEntry, FileType, Metadata};
 
@@ -63,7 +64,23 @@ struct MockState {
     /// Positional writes whose byte range covers one of these offsets
     /// fail; see [`MockCtrl::fail_write_at`].
     write_failures: BTreeMap<u64, io::ErrorKind>,
+    /// Positional reads whose requested byte range covers one of these
+    /// offsets fail; see [`MockCtrl::fail_read_at`].
+    read_failures: BTreeMap<u64, io::ErrorKind>,
+    /// Positional reads covering one of these offsets pause before they
+    /// complete, allowing tests to scramble segment completion order.
+    read_delays: BTreeMap<u64, Duration>,
+    /// Positional reads covering one of these offsets panic.
+    read_panics: BTreeSet<u64>,
+    /// One-shot behavior for the next positional reads.
+    read_actions: VecDeque<ReadAction>,
     set_len_failure: Option<io::ErrorKind>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ReadAction {
+    Interrupt,
+    Limit(usize),
 }
 
 #[derive(Debug)]
@@ -84,6 +101,10 @@ impl MockCtrl {
                 random_failure: None,
                 failures: BTreeMap::new(),
                 write_failures: BTreeMap::new(),
+                read_failures: BTreeMap::new(),
+                read_delays: BTreeMap::new(),
+                read_panics: BTreeSet::new(),
+                read_actions: VecDeque::new(),
                 set_len_failure: None,
             })),
         }
@@ -214,6 +235,38 @@ impl MockCtrl {
         self.lock().write_failures.insert(offset, kind);
     }
 
+    /// Fails positional reads covering `offset` with `kind`.
+    pub fn fail_read_at(&self, offset: u64, kind: io::ErrorKind) {
+        self.lock().read_failures.insert(offset, kind);
+    }
+
+    /// Delays positional reads covering `offset` by `duration`.
+    pub fn delay_read_at(&self, offset: u64, duration: Duration) {
+        self.lock().read_delays.insert(offset, duration);
+    }
+
+    /// Panics during positional reads covering `offset`.
+    ///
+    /// This exercises worker-panic cancellation and propagation.
+    pub fn panic_read_at(&self, offset: u64) {
+        self.lock().read_panics.insert(offset);
+    }
+
+    /// Makes the next positional read return an interrupted error.
+    ///
+    /// [`super::FileHandle::read_full_at`] retries it, which lets tests
+    /// exercise the platform-independent retry contract.
+    pub fn interrupt_next_read_at(&self) {
+        self.lock().read_actions.push_back(ReadAction::Interrupt);
+    }
+
+    /// Limits the next positional read to at most `bytes`.
+    ///
+    /// This simulates a successful short read. A zero limit simulates EOF.
+    pub fn limit_next_read_at(&self, bytes: usize) {
+        self.lock().read_actions.push_back(ReadAction::Limit(bytes));
+    }
+
     /// Makes every later file resize fail with `kind`.
     pub fn fail_set_len(&self, kind: io::ErrorKind) {
         self.lock().set_len_failure = Some(kind);
@@ -225,6 +278,10 @@ impl MockCtrl {
         state.failures.clear();
         state.random_failure = None;
         state.write_failures.clear();
+        state.read_failures.clear();
+        state.read_delays.clear();
+        state.read_panics.clear();
+        state.read_actions.clear();
         state.set_len_failure = None;
     }
 
@@ -382,6 +439,29 @@ impl MockState {
             .map(|(_offset, kind)| *kind)
     }
 
+    /// The failure injected for a read requesting
+    /// `[offset, offset+len)`, if any offset in that range has one.
+    fn read_failure_in(&self, offset: u64, len: u64) -> Option<io::ErrorKind> {
+        self.read_failures
+            .range(offset..offset.saturating_add(len))
+            .next()
+            .map(|(_offset, kind)| *kind)
+    }
+
+    fn read_delay_in(&self, offset: u64, len: u64) -> Option<Duration> {
+        self.read_delays
+            .range(offset..offset.saturating_add(len))
+            .next()
+            .map(|(_offset, duration)| *duration)
+    }
+
+    fn read_panics_in(&self, offset: u64, len: u64) -> bool {
+        self.read_panics
+            .range(offset..offset.saturating_add(len))
+            .next()
+            .is_some()
+    }
+
     /// `SplitMix64` over a run-local counter: distinct, reproducible bytes
     /// with no operating-system call.
     fn next_random_byte(&mut self) -> u8 {
@@ -414,6 +494,13 @@ pub(crate) struct MockFile {
     data: Arc<Mutex<Vec<u8>>>,
     position: u64,
     writable: bool,
+    activity: Mutex<IoActivity>,
+}
+
+#[derive(Debug, Default)]
+struct IoActivity {
+    cursor: bool,
+    positional: usize,
 }
 
 impl MockFile {
@@ -424,6 +511,7 @@ impl MockFile {
             data,
             position: 0,
             writable,
+            activity: Mutex::new(IoActivity::default()),
         }
     }
 
@@ -456,6 +544,7 @@ impl MockFile {
     /// behind their own lock, so disjoint ranges can be written through
     /// one handle from several threads.
     pub(crate) fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
+        let _activity = ActivityGuard::positional(&self.activity);
         {
             let state = self.ctrl.lock();
             state.check_failure(&self.path)?;
@@ -478,6 +567,50 @@ impl MockFile {
         Ok(buf.len())
     }
 
+    /// Reads `buf` at `offset` without changing the cursor.
+    pub(crate) fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let _activity = ActivityGuard::positional(&self.activity);
+        let (limit, failure, panics, delay) = {
+            let mut state = self.ctrl.lock();
+            state.check_failure(&self.path)?;
+            let failure = state.read_failure_in(offset, buf.len() as u64);
+            let panics = state.read_panics_in(offset, buf.len() as u64);
+            let delay = state.read_delay_in(offset, buf.len() as u64);
+            let limit = match state.read_actions.pop_front() {
+                Some(ReadAction::Interrupt) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "the mocked positional read was interrupted",
+                    ));
+                }
+                Some(ReadAction::Limit(bytes)) => bytes,
+                None => usize::MAX,
+            };
+            (limit, failure, panics, delay)
+        };
+        if let Some(duration) = delay {
+            std::thread::sleep(duration);
+        }
+        assert!(!panics, "the mocked positional read panicked");
+        if let Some(kind) = failure {
+            return Err(io::Error::new(
+                kind,
+                format!("the mocked read at offset {offset} failed"),
+            ));
+        }
+
+        let data = lock(&self.data);
+        let Ok(start) = usize::try_from(offset) else {
+            return Ok(0);
+        };
+        if start >= data.len() || limit == 0 {
+            return Ok(0);
+        }
+        let take = buf.len().min(data.len() - start).min(limit);
+        buf[..take].copy_from_slice(&data[start..start + take]);
+        Ok(take)
+    }
+
     fn check_writable(&self) -> io::Result<()> {
         if self.writable {
             Ok(())
@@ -492,6 +625,7 @@ impl MockFile {
 
 impl Read for MockFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let _activity = ActivityGuard::cursor(&self.activity);
         let data = lock(&self.data);
         let Ok(start) = usize::try_from(self.position) else {
             return Ok(0);
@@ -509,6 +643,7 @@ impl Read for MockFile {
 
 impl Write for MockFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let _activity = ActivityGuard::cursor(&self.activity);
         self.check_writable()?;
         let mut data = lock(&self.data);
         let start = usize::try_from(self.position)
@@ -533,6 +668,7 @@ impl Write for MockFile {
 
 impl Seek for MockFile {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let _activity = ActivityGuard::cursor(&self.activity);
         let length = length_of(&self.data);
         let (base, offset) = match pos {
             SeekFrom::Start(absolute) => {
@@ -547,6 +683,57 @@ impl Seek for MockFile {
             .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
         self.position = target;
         Ok(target)
+    }
+}
+
+/// Asserts that cursor-based and positional operations never overlap on
+/// one mocked handle. Multiple positional readers are intentionally
+/// allowed; the Windows implementation moves the cursor, so the
+/// verifier must complete cursor I/O before starting them.
+struct ActivityGuard<'a> {
+    activity: &'a Mutex<IoActivity>,
+    cursor: bool,
+}
+
+impl<'a> ActivityGuard<'a> {
+    fn cursor(activity: &'a Mutex<IoActivity>) -> Self {
+        let mut state = activity.lock().unwrap_or_else(PoisonError::into_inner);
+        assert_eq!(
+            state.positional, 0,
+            "cursor-based and positional file I/O overlapped"
+        );
+        assert!(!state.cursor, "cursor-based file I/O overlapped itself");
+        state.cursor = true;
+        drop(state);
+        Self {
+            activity,
+            cursor: true,
+        }
+    }
+
+    fn positional(activity: &'a Mutex<IoActivity>) -> Self {
+        let mut state = activity.lock().unwrap_or_else(PoisonError::into_inner);
+        assert!(
+            !state.cursor,
+            "cursor-based and positional file I/O overlapped"
+        );
+        state.positional += 1;
+        drop(state);
+        Self {
+            activity,
+            cursor: false,
+        }
+    }
+}
+
+impl Drop for ActivityGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.activity.lock().unwrap_or_else(PoisonError::into_inner);
+        if self.cursor {
+            state.cursor = false;
+        } else {
+            state.positional -= 1;
+        }
     }
 }
 

--- a/crates/caf-store/src/lib.rs
+++ b/crates/caf-store/src/lib.rs
@@ -10,9 +10,10 @@
 //!   orphan checks; corruption regeneration, pattern classification
 //!   ([`CorruptionPattern`]), region merging, and structured reports
 //!   ([`VerificationReport`], [`Diagnostic`], [`CorruptionReport`]).
-//! - Bounded parallel verification ([`Verifier::jobs`]): a fixed worker
-//!   pool behind a claim window, with results collected back in sorted
-//!   file order so serial and parallel reports are identical.
+//! - Bounded parallel verification ([`Verifier::jobs`]): one global
+//!   worker budget shared by concurrent files and positional segment
+//!   readers within large files, with results collected back in sorted
+//!   file and byte order so serial and parallel reports are identical.
 //! - Parallel generation of one file ([`GeneratorBuilder::jobs`]): block
 //!   generators, positional writers, and an ordered hasher over a fixed
 //!   buffer pool, producing byte-identical files at any worker count.
@@ -55,6 +56,7 @@ mod analysis;
 mod env;
 mod generate;
 mod metadata;
+mod parallel_verify;
 mod parallel_write;
 mod pipeline;
 mod random;
@@ -86,9 +88,10 @@ use std::num::NonZeroUsize;
 /// Largest worker count honored by [`Verifier::jobs`] and
 /// [`GeneratorBuilder::jobs`].
 ///
-/// A resource bound: each worker costs a thread and a block-sized
-/// buffer, and both operations saturate on I/O long before this many.
-/// Larger requests clamp to this value instead of failing to spawn.
+/// A resource bound: each worker costs a thread and verification readers
+/// can hold a few block-sized buffers. Both operations saturate on I/O
+/// long before this many. Larger requests clamp to this value instead of
+/// failing to spawn.
 pub const MAX_JOBS: NonZeroUsize = NonZeroUsize::new(256).unwrap();
 
 #[cfg(test)]

--- a/crates/caf-store/src/parallel_verify.rs
+++ b/crates/caf-store/src/parallel_verify.rs
@@ -1,0 +1,545 @@
+//! Global verification lane allocation and ordered within-file hashing.
+//!
+//! A parallel file group spends one lane on its coordinator and ordered
+//! `BLAKE2b` stream. The other lanes read 1 MiB segments positionally into
+//! a fixed buffer pool. Segment completion order is irrelevant: the
+//! coordinator absorbs them by file offset and returns each buffer to
+//! the pool. Allocation gives every remaining file one lane, then uses
+//! largest remainders to distribute spare lanes in proportion to file
+//! length, subject to the two-segments-per-lane crossover cap.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::mem;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, SyncSender};
+use std::sync::{Condvar, Mutex, MutexGuard, PoisonError};
+use std::thread;
+
+use caf_format::{BLOCK_SIZE, Digest, Hasher};
+
+use crate::env::FileHandle;
+
+/// Buffers in flight per positional reader.
+const BUFFERS_PER_READER: usize = 4;
+
+/// Number of sorted files that stay in the width-one contended regime
+/// before the final spare-lane allocation.
+///
+/// Equality is contended, so a nonempty tail is always strictly smaller
+/// than the budget. At least one full worker cohort stays on the
+/// metadata-free path before a tail is planned.
+pub(crate) fn contended_prefix_len(file_count: usize, jobs: usize) -> usize {
+    debug_assert!(jobs > 0, "the worker budget is nonzero");
+    match file_count.cmp(&jobs) {
+        std::cmp::Ordering::Less => 0,
+        std::cmp::Ordering::Equal => file_count,
+        std::cmp::Ordering::Greater => jobs.max(file_count - (jobs - 1)),
+    }
+}
+
+/// Maximum useful width for a file of `file_size` bytes.
+///
+/// Only complete 1 MiB segments count toward the crossover. This makes
+/// width two start at 4 MiB and guarantees at least two full segments
+/// of work for every assigned lane.
+pub(crate) fn width_cap(file_size: u64) -> usize {
+    let full_segments = file_size / BLOCK_SIZE as u64;
+    let cap = (full_segments / 2).max(1);
+    usize::try_from(cap).unwrap_or(usize::MAX)
+}
+
+/// Gives `lanes` to `lengths`, which are in report/path order.
+///
+/// Every file receives one lane. Spare lanes are apportioned by actual
+/// length using largest remainders, with equal remainders going to the
+/// earlier path. A capped file leaves its refused lanes for another
+/// apportionment round.
+pub(crate) fn allocate_widths(lengths: &[u64], lanes: usize) -> Vec<usize> {
+    if lengths.is_empty() {
+        return Vec::new();
+    }
+    assert!(
+        lanes >= lengths.len(),
+        "lane allocation requires at least one lane per file"
+    );
+
+    let caps: Vec<usize> = lengths.iter().copied().map(width_cap).collect();
+    let mut widths = vec![1_usize; lengths.len()];
+    let mut spare = lanes - lengths.len();
+
+    while spare > 0 {
+        let eligible: Vec<usize> = (0..lengths.len())
+            .filter(|&index| widths[index] < caps[index])
+            .collect();
+        if eligible.is_empty() {
+            break;
+        }
+        let total_weight: u128 = eligible
+            .iter()
+            .map(|&index| u128::from(lengths[index]))
+            .sum();
+        debug_assert!(total_weight > 0, "a file with spare capacity is nonempty");
+
+        let round_spare = spare;
+        let mut remainders = Vec::with_capacity(eligible.len());
+        for &index in &eligible {
+            let numerator = round_spare as u128 * u128::from(lengths[index]);
+            let quotient = usize::try_from(numerator / total_weight)
+                .expect("a proportional share is no larger than the lane budget");
+            let grant = quotient.min(caps[index] - widths[index]);
+            widths[index] += grant;
+            spare -= grant;
+            remainders.push((numerator % total_weight, index));
+        }
+
+        // Descending remainder, then ascending path index.
+        remainders.sort_unstable_by(|(left_rem, left_index), (right_rem, right_index)| {
+            right_rem
+                .cmp(left_rem)
+                .then_with(|| left_index.cmp(right_index))
+        });
+        for (_remainder, index) in remainders {
+            if spare == 0 {
+                break;
+            }
+            if widths[index] < caps[index] {
+                widths[index] += 1;
+                spare -= 1;
+            }
+        }
+    }
+    widths
+}
+
+/// Hashes `header_bytes` followed by every actual file byte after the
+/// header, overlapping positional reads with the ordered hash stream.
+///
+/// `width` counts this calling coordinator, so exactly `width - 1`
+/// reader threads are started. Read failures are compared by segment
+/// index and the lowest-offset one is returned. A reader panic cancels
+/// and drains the group before resuming on the coordinator.
+pub(crate) fn hash_file(
+    file: &FileHandle,
+    header_bytes: &[u8],
+    actual_size: u64,
+    width: usize,
+) -> io::Result<Digest> {
+    assert!(width >= 2, "parallel hashing needs a reader and a hasher");
+    let content_start = header_bytes.len() as u64;
+    let content_len = actual_size.saturating_sub(content_start);
+    let total = content_len.div_ceil(BLOCK_SIZE as u64);
+
+    let mut hasher = Hasher::new();
+    hasher.update(header_bytes);
+    if total == 0 {
+        return Ok(hasher.finalize());
+    }
+
+    let readers = usize::try_from(total).unwrap_or(usize::MAX).min(width - 1);
+    let buffer_count = usize::try_from(total)
+        .unwrap_or(usize::MAX)
+        .min(readers.saturating_mul(BUFFERS_PER_READER));
+    let pool = Pool::new(buffer_count);
+    let next_index = AtomicU64::new(0);
+    let (sender, receiver) = mpsc::sync_channel(buffer_count);
+
+    let (failure, panic_payload, next_hashed) = thread::scope(|scope| {
+        for _ in 0..readers {
+            let sender = sender.clone();
+            let pool = &pool;
+            let next_index = &next_index;
+            scope.spawn(move || {
+                let worked = panic::catch_unwind(AssertUnwindSafe(|| {
+                    read_segments(
+                        file,
+                        content_start,
+                        content_len,
+                        total,
+                        pool,
+                        next_index,
+                        &sender,
+                    );
+                }));
+                if let Err(payload) = worked {
+                    pool.cancel();
+                    let _ignored = sender.send(Message::Panic(payload));
+                }
+            });
+        }
+        drop(sender);
+
+        let mut pending = BTreeMap::new();
+        let mut next_hashed = 0_u64;
+        let mut failure: Option<(u64, io::Error)> = None;
+        let mut panic_payload = None;
+        for message in receiver {
+            match message {
+                Message::Segment(segment) if failure.is_none() && panic_payload.is_none() => {
+                    pending.insert(segment.index, segment);
+                    while let Some(segment) = pending.remove(&next_hashed) {
+                        hasher.update(segment.bytes());
+                        next_hashed += 1;
+                    }
+                }
+                Message::Segment(_segment) => {}
+                Message::Error { index, source } => {
+                    if failure
+                        .as_ref()
+                        .is_none_or(|(recorded, _source)| index < *recorded)
+                    {
+                        failure = Some((index, source));
+                    }
+                    pending.clear();
+                }
+                Message::Panic(payload) => {
+                    if panic_payload.is_none() {
+                        panic_payload = Some(payload);
+                    }
+                    pending.clear();
+                }
+            }
+        }
+        (failure, panic_payload, next_hashed)
+    });
+
+    debug_assert_eq!(pool.free(), buffer_count, "every read buffer returns");
+    if let Some(payload) = panic_payload {
+        panic::resume_unwind(payload);
+    }
+    if let Some((_index, source)) = failure {
+        return Err(source);
+    }
+    debug_assert_eq!(next_hashed, total, "every successful segment is hashed");
+    Ok(hasher.finalize())
+}
+
+fn read_segments<'pool>(
+    file: &FileHandle,
+    content_start: u64,
+    content_len: u64,
+    total: u64,
+    pool: &'pool Pool,
+    next_index: &AtomicU64,
+    sender: &SyncSender<Message<'pool>>,
+) {
+    // Taking a buffer before claiming an index guarantees that the
+    // lowest outstanding segment always has a reader and bounds claims
+    // to the pool size ahead of the hasher.
+    while let Some(mut buffer) = pool.take() {
+        let index = next_index.fetch_add(1, Ordering::Relaxed);
+        if index >= total {
+            return;
+        }
+        let relative = index * BLOCK_SIZE as u64;
+        let len = usize::try_from((content_len - relative).min(BLOCK_SIZE as u64))
+            .expect("a segment is at most BLOCK_SIZE bytes");
+        buffer.bytes.resize(len, 0);
+        let offset = content_start + relative;
+        match file.read_full_at(&mut buffer.bytes, offset) {
+            Ok(got) => {
+                buffer.bytes.truncate(got);
+                if sender
+                    .send(Message::Segment(Segment { index, buffer }))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Err(source) => {
+                pool.cancel();
+                let _ignored = sender.send(Message::Error { index, source });
+                return;
+            }
+        }
+    }
+}
+
+enum Message<'pool> {
+    Segment(Segment<'pool>),
+    Error { index: u64, source: io::Error },
+    Panic(Box<dyn std::any::Any + Send>),
+}
+
+struct Segment<'pool> {
+    index: u64,
+    buffer: Buffer<'pool>,
+}
+
+impl Segment<'_> {
+    fn bytes(&self) -> &[u8] {
+        &self.buffer.bytes
+    }
+}
+
+/// One pool buffer on loan. Its destructor is the cancellation and panic
+/// safety protocol: every exit path returns the allocation.
+struct Buffer<'pool> {
+    bytes: Vec<u8>,
+    pool: &'pool Pool,
+}
+
+impl Drop for Buffer<'_> {
+    fn drop(&mut self) {
+        self.pool.put(mem::take(&mut self.bytes));
+    }
+}
+
+/// Fixed read buffers and cancellation wakeup for one file group.
+struct Pool {
+    state: Mutex<PoolState>,
+    returned: Condvar,
+}
+
+struct PoolState {
+    free: Vec<Vec<u8>>,
+    cancelled: bool,
+}
+
+impl Pool {
+    fn new(buffers: usize) -> Self {
+        Self {
+            state: Mutex::new(PoolState {
+                free: (0..buffers)
+                    .map(|_| Vec::with_capacity(BLOCK_SIZE))
+                    .collect(),
+                cancelled: false,
+            }),
+            returned: Condvar::new(),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, PoolState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn take(&self) -> Option<Buffer<'_>> {
+        let mut state = self.lock();
+        loop {
+            if state.cancelled {
+                return None;
+            }
+            if let Some(buffer) = state.free.pop() {
+                return Some(Buffer {
+                    bytes: buffer,
+                    pool: self,
+                });
+            }
+            state = self
+                .returned
+                .wait(state)
+                .unwrap_or_else(PoisonError::into_inner);
+        }
+    }
+
+    fn put(&self, buffer: Vec<u8>) {
+        self.lock().free.push(buffer);
+        self.returned.notify_one();
+    }
+
+    fn cancel(&self) {
+        self.lock().cancelled = true;
+        self.returned.notify_all();
+    }
+
+    fn free(&self) -> usize {
+        self.lock().free.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{allocate_widths, contended_prefix_len, width_cap};
+    use caf_format::BLOCK_SIZE;
+
+    #[test]
+    fn contended_files_stay_width_one_until_fewer_than_jobs_remain() {
+        assert_eq!(contended_prefix_len(5, 24), 0);
+        assert_eq!(contended_prefix_len(5, 5), 5);
+        assert_eq!(contended_prefix_len(25, 24), 24);
+        assert_eq!(contended_prefix_len(100, 24), 77);
+        assert_eq!(100 - contended_prefix_len(100, 24), 23);
+    }
+
+    #[test]
+    fn equal_files_split_spares_by_path_order() {
+        let one_tib = 1024_u64 * 1024 * 1024 * 1024;
+        assert_eq!(allocate_widths(&[one_tib; 5], 24), [5, 5, 5, 5, 4]);
+    }
+
+    #[test]
+    fn file_width_requires_two_complete_segments_per_lane() {
+        let mib = BLOCK_SIZE as u64;
+        assert_eq!(width_cap(4 * mib - 1), 1);
+        assert_eq!(width_cap(4 * mib), 2);
+        assert_eq!(width_cap(5 * mib), 2);
+        assert_eq!(width_cap(6 * mib), 3);
+    }
+
+    #[test]
+    fn capped_lanes_redistribute_to_files_that_can_use_them() {
+        let mib = BLOCK_SIZE as u64;
+        assert_eq!(allocate_widths(&[4 * mib, 40 * mib], 8), [2, 6]);
+        assert_eq!(allocate_widths(&[mib, 40 * mib, mib], 8), [1, 6, 1]);
+    }
+
+    #[test]
+    fn mixed_sizes_use_largest_remainders() {
+        let mib = BLOCK_SIZE as u64;
+        assert_eq!(
+            allocate_widths(&[8 * mib, 16 * mib, 24 * mib], 10),
+            [2, 3, 5]
+        );
+    }
+}
+
+#[cfg(all(test, feature = "test-util"))]
+mod mocked_tests {
+    use std::io::{self, Read as _};
+    use std::panic::{self, AssertUnwindSafe};
+    use std::path::Path;
+    use std::time::Duration;
+
+    use caf_format::{BLOCK_SIZE, Digest};
+
+    use super::hash_file;
+    use crate::env::Env;
+
+    fn bytes(len: usize) -> Vec<u8> {
+        (0..len)
+            .map(|index| u8::try_from((index * 37 + 11) % 251).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn ordered_pipeline_matches_one_shot_digest_at_blake2_boundaries() {
+        for header_len in [127_usize, 128, 129] {
+            let data = bytes(4 * BLOCK_SIZE + 17);
+            let expected = Digest::compute(&data);
+            let (env, ctrl) = Env::mocked();
+            ctrl.write_file("/file", data)
+                .expect("the fixture is writable");
+            let mut file = env.open(Path::new("/file")).expect("the file opens");
+            let mut header = vec![0_u8; header_len];
+            file.read_exact(&mut header)
+                .expect("the header is readable");
+
+            let actual = hash_file(&file, &header, 4 * BLOCK_SIZE as u64 + 17, 4)
+                .expect("parallel reads succeed");
+            assert_eq!(actual, expected, "header length {header_len}");
+        }
+    }
+
+    #[test]
+    fn ordered_pipeline_retries_interrupted_and_short_reads() {
+        let data = bytes(4 * BLOCK_SIZE);
+        let expected = Digest::compute(&data);
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", data)
+            .expect("the fixture is writable");
+        let mut file = env.open(Path::new("/file")).expect("the file opens");
+        let mut header = [0_u8; 60];
+        file.read_exact(&mut header)
+            .expect("the header is readable");
+        ctrl.interrupt_next_read_at();
+        ctrl.limit_next_read_at(17);
+
+        let actual =
+            hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 2).expect("parallel reads retry");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn ordered_pipeline_caps_readers_and_buffers_by_segment_count() {
+        let data = bytes(BLOCK_SIZE + 17);
+        let expected = Digest::compute(&data);
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", data)
+            .expect("the fixture is writable");
+        let mut file = env.open(Path::new("/file")).expect("the file opens");
+        let mut header = [0_u8; 60];
+        file.read_exact(&mut header)
+            .expect("the header is readable");
+
+        let actual = hash_file(&file, &header, BLOCK_SIZE as u64 + 17, 64)
+            .expect("more lanes than segments are harmless");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn ordered_pipeline_surfaces_injected_positional_read_failures() {
+        let data = bytes(4 * BLOCK_SIZE);
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", data)
+            .expect("the fixture is writable");
+        let mut file = env.open(Path::new("/file")).expect("the file opens");
+        let mut header = [0_u8; 60];
+        file.read_exact(&mut header)
+            .expect("the header is readable");
+        ctrl.fail_read_at(BLOCK_SIZE as u64 + 100, io::ErrorKind::PermissionDenied);
+
+        let error = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 4)
+            .expect_err("the injected read fails");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn ordered_pipeline_reorders_scrambled_segments() {
+        let data = bytes(4 * BLOCK_SIZE);
+        let expected = Digest::compute(&data);
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", data)
+            .expect("the fixture is writable");
+        let mut file = env.open(Path::new("/file")).expect("the file opens");
+        let mut header = [0_u8; 60];
+        file.read_exact(&mut header)
+            .expect("the header is readable");
+        ctrl.delay_read_at(60, Duration::from_millis(30));
+
+        let actual = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3)
+            .expect("out-of-order reads succeed");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn lowest_offset_read_error_wins_after_a_later_error() {
+        let data = bytes(4 * BLOCK_SIZE);
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", data)
+            .expect("the fixture is writable");
+        let mut file = env.open(Path::new("/file")).expect("the file opens");
+        let mut header = [0_u8; 60];
+        file.read_exact(&mut header)
+            .expect("the header is readable");
+        ctrl.delay_read_at(60, Duration::from_millis(30));
+        ctrl.fail_read_at(100, io::ErrorKind::PermissionDenied);
+        ctrl.fail_read_at(BLOCK_SIZE as u64 + 100, io::ErrorKind::StorageFull);
+
+        let error = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3)
+            .expect_err("both initial segments fail");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn reader_panic_cancels_siblings_and_resumes_on_the_coordinator() {
+        let data = bytes(4 * BLOCK_SIZE);
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", data)
+            .expect("the fixture is writable");
+        let mut file = env.open(Path::new("/file")).expect("the file opens");
+        let mut header = [0_u8; 60];
+        file.read_exact(&mut header)
+            .expect("the header is readable");
+        ctrl.panic_read_at(BLOCK_SIZE as u64 + 100);
+
+        let payload = panic::catch_unwind(AssertUnwindSafe(|| {
+            hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3)
+        }))
+        .expect_err("the reader panic reaches the coordinator");
+        assert_eq!(
+            payload.downcast_ref::<&str>(),
+            Some(&"the mocked positional read panicked")
+        );
+    }
+}

--- a/crates/caf-store/src/verify.rs
+++ b/crates/caf-store/src/verify.rs
@@ -7,25 +7,30 @@
 //! [`Header::parse`] implementation, which also rejects nonzero reserved
 //! bytes and file lengths below the header size.
 //!
-//! Clean files cost one sequential read: header parse, size check, and
-//! a whole-file BLAKE2b-160 pass. Expected content is regenerated for
+//! Clean files cost one complete read: header parse, size check, and a
+//! whole-file BLAKE2b-160 pass. Large-file groups may overlap positional
+//! reads with that ordered hash. Expected content is regenerated for
 //! [corruption analysis](crate::CorruptionReport) only after the digest
-//! or size check fails. Results are structured ([`VerificationReport`],
-//! [`Diagnostic`]); nothing here prints or renders.
+//! fails. Results are structured ([`VerificationReport`], [`Diagnostic`]);
+//! nothing here prints or renders.
 //!
-//! [`Verifier::jobs`] validates files on a bounded worker pipeline.
-//! Serial and parallel runs produce identical reports:
-//! per-file work is order-independent, and the [`pipeline`] collector
-//! folds results back in sorted file order before the store-level
-//! checks run.
+//! [`Verifier::jobs`] is a global verification-worker budget. Contended
+//! stores use the existing bounded file pipeline; when lanes outnumber
+//! unstarted files, spare lanes read and analyze segments within large
+//! files. Serial and parallel runs produce identical reports: per-file
+//! work is order-independent, and collectors fold results back in sorted
+//! file order before the store-level checks run.
 
 use std::backtrace::Backtrace;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Display, Formatter};
 use std::io::{self, Read};
 use std::num::NonZeroUsize;
+use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
 
 use caf_format::{
     BLOCK_SIZE, Digest, HEADER_SIZE, Hasher, Header, HeaderError, hash_to_path,
@@ -35,7 +40,7 @@ use caf_format::{
 use crate::analysis::{self, CorruptionReport, read_full};
 use crate::env::{DirEntry, Env};
 use crate::metadata::{ALL_FILE, METADATA_DIR, ROOTS_DIR};
-use crate::{MAX_JOBS, pipeline};
+use crate::{MAX_JOBS, parallel_verify, pipeline};
 
 /// Default corruption-analysis chunk size in bytes.
 pub const DEFAULT_ANALYSIS_CHUNK_SIZE: NonZeroUsize = NonZeroUsize::new(4096).unwrap();
@@ -132,15 +137,17 @@ impl Verifier {
         self
     }
 
-    /// Validates files on `count` worker threads (default 1, serial).
+    /// Sets the store-wide verification worker limit.
     ///
-    /// The report is identical to a serial run: per-file validation is
-    /// order-independent, results are folded back in sorted file order
-    /// and store-level checks run after every file.
-    /// Peak memory grows with the worker count (one block-sized read
-    /// buffer per worker), never with the number of files queued. Values
-    /// above [`MAX_JOBS`] clamp to it. The CLI rejects values below one
-    /// as a usage error.
+    /// The default is one worker, which runs serially. Different files run
+    /// concurrently. When the worker budget exceeds
+    /// the remaining file count, large files receive spare workers for
+    /// positional reads and corruption analysis. The report is identical
+    /// to a serial run: results are folded back in sorted file order and
+    /// store-level checks run after every file. Peak memory grows with the
+    /// worker count, never with file size or the number of queued files.
+    /// Values above [`MAX_JOBS`] clamp to it. The CLI rejects values below
+    /// one as a usage error.
     #[must_use]
     pub fn jobs(mut self, count: NonZeroUsize) -> Self {
         self.jobs = count.min(MAX_JOBS);
@@ -185,14 +192,15 @@ impl Verifier {
         let files = collect_data_files(&self.env, &self.root)?;
         let files_checked = files.len() as u64;
         let mut checks = StoreChecks::new(files.len());
+        let analysis_memory = analysis::AnalysisMemory::new();
 
         if self.jobs == NonZeroUsize::MIN {
             let mut buffer = vec![0_u8; BLOCK_SIZE];
             for path in files {
-                checks.absorb(self.validate_file(path, &mut buffer)?);
+                checks.absorb(self.validate_file(path, 1, &mut buffer, &analysis_memory)?);
             }
         } else {
-            self.validate_files_parallel(&files, &mut checks)?;
+            self.validate_files_parallel(&files, &mut checks, &analysis_memory)?;
         }
 
         let mut diagnostics = checks.into_diagnostics(&marker_set);
@@ -210,28 +218,131 @@ impl Verifier {
         })
     }
 
-    /// Validates `files` on [`Verifier::jobs`] worker threads, folding
-    /// outcomes into `checks` in sorted file order.
+    /// Runs the contended file pipeline, then lends all lanes across the
+    /// final set of fewer-than-`jobs` files. The prefix keeps persistent
+    /// worker buffers and performs no metadata planning, preserving the
+    /// small-file path; tail outcomes are still folded in path order.
     fn validate_files_parallel(
         &self,
         files: &[PathBuf],
         checks: &mut StoreChecks,
+        analysis_memory: &analysis::AnalysisMemory,
+    ) -> Result<(), VerifyError> {
+        let jobs = self.jobs.get();
+        let contended = parallel_verify::contended_prefix_len(files.len(), jobs);
+
+        if contended > 0 {
+            self.validate_contended_files(&files[..contended], checks, analysis_memory)?;
+        }
+        self.validate_tail_files(&files[contended..], checks, analysis_memory)
+    }
+
+    /// The existing file-level regime: fixed workers, no length planning,
+    /// and four claims of run-ahead per requested job.
+    fn validate_contended_files(
+        &self,
+        files: &[PathBuf],
+        checks: &mut StoreChecks,
+        analysis_memory: &analysis::AnalysisMemory,
     ) -> Result<(), VerifyError> {
         pipeline::run(
             files.len(),
             self.jobs,
             || {
                 let mut buffer = vec![0_u8; BLOCK_SIZE];
-                move |index: usize| self.validate_file(files[index].clone(), &mut buffer)
+                move |index: usize| {
+                    self.validate_file(files[index].clone(), 1, &mut buffer, analysis_memory)
+                }
             },
             |outcome| checks.absorb(outcome),
         )
     }
 
+    /// Plans and runs the remaining files when the free lanes outnumber
+    /// them. Planning metadata failures deliberately give that path width
+    /// one and are retried by normal validation, preserving its existing
+    /// open/metadata error and sorted-error behavior.
+    fn validate_tail_files(
+        &self,
+        files: &[PathBuf],
+        checks: &mut StoreChecks,
+        analysis_memory: &analysis::AnalysisMemory,
+    ) -> Result<(), VerifyError> {
+        if files.is_empty() {
+            return Ok(());
+        }
+        let lengths: Vec<u64> = files
+            .iter()
+            .map(|path| self.env.metadata(path).map_or(0, crate::env::Metadata::len))
+            .collect();
+        let widths = parallel_verify::allocate_widths(&lengths, self.jobs.get());
+        let mut start_order: Vec<usize> = (0..files.len()).collect();
+        start_order.sort_unstable_by(|&left, &right| {
+            lengths[right]
+                .cmp(&lengths[left])
+                .then_with(|| left.cmp(&right))
+        });
+
+        let (sender, receiver) = mpsc::channel();
+        let (mut outcomes, panic_payload) = thread::scope(|scope| {
+            for index in start_order {
+                let sender = sender.clone();
+                let path = files[index].clone();
+                let width = widths[index];
+                scope.spawn(move || {
+                    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                        let mut buffer = Vec::new();
+                        self.validate_file(path, width, &mut buffer, analysis_memory)
+                    }));
+                    let message = match result {
+                        Ok(result) => TailMessage::Outcome { index, result },
+                        Err(payload) => TailMessage::Panic(payload),
+                    };
+                    let _ignored = sender.send(message);
+                });
+            }
+            drop(sender);
+
+            let mut outcomes = BTreeMap::new();
+            let mut panic_payload = None;
+            for message in receiver {
+                match message {
+                    TailMessage::Outcome { index, result } => {
+                        outcomes.insert(index, result);
+                    }
+                    TailMessage::Panic(payload) => {
+                        if panic_payload.is_none() {
+                            panic_payload = Some(payload);
+                        }
+                    }
+                }
+            }
+            (outcomes, panic_payload)
+        });
+
+        if let Some(payload) = panic_payload {
+            panic::resume_unwind(payload);
+        }
+        for index in 0..files.len() {
+            checks.absorb(
+                outcomes
+                    .remove(&index)
+                    .expect("every tail group returns an outcome unless it panics")?,
+            );
+        }
+        Ok(())
+    }
+
     /// Validates one data file and returns everything it contributes to
     /// the report. Self-contained per file, so serial and parallel runs
     /// produce identical outcomes.
-    fn validate_file(&self, path: PathBuf, buffer: &mut [u8]) -> Result<FileOutcome, VerifyError> {
+    fn validate_file(
+        &self,
+        path: PathBuf,
+        width: usize,
+        buffer: &mut Vec<u8>,
+        analysis_memory: &analysis::AnalysisMemory,
+    ) -> Result<FileOutcome, VerifyError> {
         let mut diagnostics = Vec::new();
         let Ok(digest_from_path) = parse_hash_from_path(&path) else {
             diagnostics.push(Diagnostic::InvalidPathLayout { path: path.clone() });
@@ -283,16 +394,35 @@ impl Verifier {
             });
         }
 
-        // The clean fast path: one sequential read through BLAKE2b-160.
-        let actual_digest = hash_whole_file(&mut file, &header_bytes[..header_len], buffer)
-            .map_err(|source| VerifyError::io("reading a data file", &path, source))?;
+        // Reapply the cap to the opened file's size. Planning metadata
+        // normally matches it, but this keeps a failed/stale planning
+        // read from ever creating more lanes than the crossover allows.
+        let width = width.min(parallel_verify::width_cap(actual_size));
+        let parallel = width >= 2;
+        let actual_digest = if parallel {
+            parallel_verify::hash_file(&file, &header_bytes[..header_len], actual_size, width)
+        } else {
+            if buffer.is_empty() {
+                buffer.resize(BLOCK_SIZE, 0);
+            }
+            hash_whole_file(&mut file, &header_bytes[..header_len], buffer)
+        }
+        .map_err(|source| VerifyError::io("reading a data file", &path, source))?;
 
         if actual_digest != digest_from_path {
-            let regions =
+            let regions = if parallel {
+                analysis::analyze_parallel(
+                    &file,
+                    &header,
+                    actual_size,
+                    self.analysis_chunk_size,
+                    width,
+                    analysis_memory,
+                )
+            } else {
                 analysis::analyze(&mut file, &header, actual_size, self.analysis_chunk_size)
-                    .map_err(|source| {
-                        VerifyError::io("analyzing a corrupted file", &path, source)
-                    })?;
+            }
+            .map_err(|source| VerifyError::io("analyzing a corrupted file", &path, source))?;
             diagnostics.push(Diagnostic::DigestMismatch {
                 report: CorruptionReport {
                     path: path.clone(),
@@ -382,6 +512,14 @@ impl Verifier {
         }
         Ok(())
     }
+}
+
+enum TailMessage {
+    Outcome {
+        index: usize,
+        result: Result<FileOutcome, VerifyError>,
+    },
+    Panic(Box<dyn std::any::Any + Send>),
 }
 
 /// What one data file contributed to the store-level checks.

--- a/crates/caf-store/tests/verification.rs
+++ b/crates/caf-store/tests/verification.rs
@@ -10,7 +10,9 @@ use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
-use caf_format::{ContentReader, ContentSeed, Digest, HEADER_SIZE, Hasher, Header, hash_to_path};
+use caf_format::{
+    BLOCK_SIZE, ContentReader, ContentSeed, Digest, HEADER_SIZE, Hasher, Header, hash_to_path,
+};
 use caf_store::{
     CorruptionClass, CorruptionPattern, Diagnostic, GenerationReport, Generator, Severity,
     SizeChooser, VerificationReport, Verifier,
@@ -979,17 +981,68 @@ fn parallel_verification_matches_serial_on_a_clean_store() {
 }
 
 #[test]
+fn within_file_digest_and_analysis_match_serial_across_boundaries() {
+    let store = tempfile::tempdir().expect("create temp store");
+    generate(store.path(), 1, 9 * BLOCK_SIZE as u64 + 1);
+    let [file] = &*data_files(store.path()) else {
+        panic!("exactly one data file is generated");
+    };
+    // Cross both kinds of boundary: CAF blocks begin at absolute 1 MiB
+    // offsets, while verification segments begin after the 60-byte
+    // header. The non-divisor analysis chunk also crosses both rather
+    // than accidentally splitting there.
+    overwrite(file, BLOCK_SIZE as u64 - 17, &[0xA5; 64]);
+    overwrite(
+        file,
+        HEADER_SIZE as u64 + 4 * BLOCK_SIZE as u64 - 19,
+        &[0x5A; 80],
+    );
+    let chunk_size = positive(70_001);
+    let serial = Verifier::new(store.path())
+        .analysis_chunk_size(chunk_size)
+        .verify()
+        .expect("serial verification runs");
+    assert!(!serial.success());
+
+    for jobs in [2, 4, 8, 16] {
+        let parallel = Verifier::new(store.path())
+            .analysis_chunk_size(chunk_size)
+            .jobs(positive(jobs))
+            .verify()
+            .expect("parallel verification runs");
+        let serial_keys: Vec<String> = serial.diagnostics().iter().map(diagnostic_key).collect();
+        let parallel_keys: Vec<String> =
+            parallel.diagnostics().iter().map(diagnostic_key).collect();
+        assert_eq!(parallel_keys, serial_keys, "jobs {jobs}");
+    }
+}
+
+#[test]
 fn parallel_verification_matches_serial_on_a_corrupted_store() {
     // One store with every diagnostic family at once: content
-    // corruption, truncation, a stray temp file, a wrong-path copy,
-    // and a broken chain (missing parent plus orphan).
+    // corruption, truncation, an invalid header, a stray temp file, a
+    // wrong-path copy, a broken chain (missing parent plus orphan), and
+    // a bad chain-tip aggregate.
     let store = tempfile::tempdir().expect("create temp store");
     let generation = generate(store.path(), 12, 2048);
     let files = data_files(store.path());
-    overwrite(&files[1], 100, b"corrupt_data");
-    truncate(&files[3], 1024);
+    let victim = hash_to_path(
+        store.path(),
+        parent_of(store.path(), generation.chain_tip()),
+    );
+    let fixtures: Vec<&PathBuf> = files
+        .iter()
+        .filter(|path| *path != &victim)
+        .take(4)
+        .collect();
+    let [content_file, truncated_file, copy_file, invalid_header] = &*fixtures else {
+        panic!("enough generated files remain for every corruption fixture");
+    };
+    overwrite(content_file, 100, b"corrupt_data");
+    truncate(truncated_file, 1024);
+    overwrite(invalid_header, 55, &[0x01]);
     fs::write(store.path().join("00000000000000005678cdef"), b"stray").expect("write the stray");
-    let copy_bytes = fs::read(&files[5]).expect("data files are readable");
+    let copy_bytes = fs::read(copy_file).expect("data files are readable");
     let real_digest = Digest::compute(&copy_bytes);
     let mut hex = real_digest.to_hex();
     let flipped = if hex.starts_with('0') { "f" } else { "0" };
@@ -999,8 +1052,8 @@ fn parallel_verification_matches_serial_on_a_corrupted_store() {
     fs::create_dir_all(wrong_path.parent().expect("hash paths have parents"))
         .expect("create shard directories");
     fs::write(&wrong_path, &copy_bytes).expect("write the copy");
-    let victim = parent_of(store.path(), generation.chain_tip());
-    fs::remove_file(hash_to_path(store.path(), victim)).expect("delete the mid-chain file");
+    fs::remove_file(victim).expect("delete the mid-chain file");
+    fs::write(store.path().join(".metadata/all"), b"bad").expect("damage the aggregate");
 
     let serial = verify(store.path());
     assert!(!serial.success());
@@ -1009,7 +1062,7 @@ fn parallel_verification_matches_serial_on_a_corrupted_store() {
         "{:?}",
         serial.diagnostics()
     );
-    for jobs in [2, 4, 8] {
+    for jobs in [1, 2, 4, 8, 32] {
         assert_matches_serial(store.path(), &serial, jobs);
     }
 }

--- a/crates/caf/src/verify.rs
+++ b/crates/caf/src/verify.rs
@@ -30,6 +30,10 @@ detection:
     - 4096 bytes: Standard 4KB block analysis (default)
     - 65536 bytes: Fast scanning for large files
 
+The --jobs option is a global verification-worker budget. Files are
+validated concurrently, and spare workers read and analyze segments of
+large files while their ordered whole-file digest is computed.
+
 When corruption is detected, the verifier will:
 
     - Identify exact corrupted byte ranges
@@ -56,8 +60,10 @@ pub struct Args {
     )]
     chunk_size: NonZeroUsize,
 
-    /// Number of worker threads for file validation. Defaults to 1
-    /// (serial verification); results are identical at any count.
+    /// Global verification-worker budget. Different files run in
+    /// parallel, and large files use spare workers for segment reads and
+    /// corruption analysis. Defaults to 1 (serial verification); results
+    /// are identical at any count.
     #[arg(
         long,
         value_name = "INTEGER",


### PR DESCRIPTION
Previously `--jobs` only spread verification across files, so a store dominated by one large file gained nothing from extra workers. The budget is now global: the contended prefix keeps the existing bounded file pipeline, and once fewer unstarted files remain than workers, the spare lanes are lent into large files — positional 1 MiB segment reads feed the ordered whole-file BLAKE2b digest, and corruption analysis compares task-sized ranges in parallel. Reports stay byte-identical at any worker count: segments and analysis tasks are merged by index, and when several lanes fail, the lowest-offset I/O error wins deterministically.

* Add `ContentReader::at_offset`, which positions the SHAKE content stream at any `u64` content offset with direct block arithmetic instead of streaming through the prefix, so analysis tasks can regenerate expected content independently
* Add `FileHandle::read_at`/`read_full_at` positional reads with an interrupted-read retry loop and EOF handling shared across platforms
* Add a `parallel_verify` module: contended-prefix planning, per-file width caps requiring two full segments per lane, largest-remainder spare-lane apportionment by file length, and the ordered segment hashing pipeline over a fixed buffer pool
* Run corruption analysis on parallel lanes under a shared 256 MiB actual-plus-expected memory budget (`AnalysisMemory`), with a bounded reorder window and abort paths that wake blocked siblings on error or panic
* Extend the mocked env with positional-read fault injection (failures, delays, panics, interrupts, short reads) and an assertion that cursor-based and positional I/O never overlap on one handle, since Windows `seek_read` moves the cursor
* Rework the verification benchmarks around the new regimes: one large file, five equal large files, and corruption near the start, middle, and end, each across several worker counts