### PR TITLE
Show live generation and verification progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ caf gen --max-files 1 --file-size 4GB --jobs 8
 caf verify --jobs 8
 ```
 
+In an interactive terminal, both commands show live byte/file progress,
+throughput, and an estimated time remaining. Progress is rendered on standard
+error and is automatically disabled when output is redirected or captured.
+
 Run `caf gen --help` for size distributions and more examples. See the
 [file-format specification](docs/file-format.md) for the v2 and v3 header,
 content, identity, path, chain, and metadata rules.

--- a/crates/caf-store/src/generate.rs
+++ b/crates/caf-store/src/generate.rs
@@ -35,6 +35,7 @@ use caf_format::{
 };
 
 use crate::env::Env;
+use crate::progress::{OperationProgress, ProgressCallback, ProgressTracker};
 use crate::size::{SampleError, SizeChooser};
 use crate::temp::TempFile;
 use crate::{MAX_JOBS, default_jobs, metadata, parallel_write};
@@ -89,6 +90,7 @@ pub struct Generator {
     sizes: SizeChooser,
     jobs: NonZeroUsize,
     write_threads: NonZeroUsize,
+    progress: Option<ProgressCallback>,
 }
 
 impl Generator {
@@ -139,6 +141,8 @@ impl Generator {
 
         let max_files = self.max_files.unwrap_or(u64::MAX);
         let max_disk_usage = self.max_disk_usage.unwrap_or(u64::MAX);
+        let (total_bytes, total_files) = self.progress_totals();
+        let progress = ProgressTracker::new(self.progress.clone(), total_bytes, total_files);
         let mut buffer = vec![0_u8; BLOCK_SIZE];
         let mut created_dirs = HashSet::new();
         let mut parent = Digest::ZERO;
@@ -151,9 +155,11 @@ impl Generator {
                 .next_size()
                 .map_err(GenerateError::size_selection)?;
             let file_size = requested.max(MIN_FILE_SIZE);
-            parent = self.write_file(parent, file_size, &mut buffer, &mut created_dirs)?;
+            parent =
+                self.write_file(parent, file_size, &mut buffer, &mut created_dirs, &progress)?;
             files_created += 1;
             bytes_written = bytes_written.saturating_add(file_size);
+            progress.finish_file();
         }
 
         metadata::write_chain_tip(&self.env, &self.root, parent)?;
@@ -167,6 +173,32 @@ impl Generator {
         })
     }
 
+    /// Returns the best byte/file totals known before generation starts.
+    /// A fixed chooser makes the exact stopping point calculable; sampled
+    /// sizes retain their configured limits instead.
+    fn progress_totals(&self) -> (Option<u64>, Option<u64>) {
+        let Some(file_size) = self.sizes.fixed_size().map(|size| size.max(MIN_FILE_SIZE)) else {
+            return (self.max_disk_usage, self.max_files);
+        };
+        let files_for_disk = self.max_disk_usage.map(|limit| {
+            if limit == 0 {
+                0
+            } else {
+                limit.div_ceil(file_size)
+            }
+        });
+        let total_files = match (self.max_files, files_for_disk) {
+            (Some(files), Some(for_disk)) => Some(files.min(for_disk)),
+            (files @ Some(_), None) => files,
+            (None, for_disk @ Some(_)) => for_disk,
+            (None, None) => None,
+        };
+        (
+            total_files.map(|files| files.saturating_mul(file_size)),
+            total_files,
+        )
+    }
+
     /// Writes one file: header, deterministic content, and hash-derived
     /// placement. Returns the file's identity (the next file's parent).
     fn write_file(
@@ -175,6 +207,7 @@ impl Generator {
         file_size: u64,
         buffer: &mut [u8],
         created_dirs: &mut HashSet<PathBuf>,
+        progress: &ProgressTracker,
     ) -> Result<Digest, GenerateError> {
         let seed =
             ContentSeed::from_bytes(self.env.random_array().map_err(GenerateError::randomness)?);
@@ -193,9 +226,15 @@ impl Generator {
         // Both paths produce the same bytes and the same identity; only
         // the thread count differs.
         let digest = if use_parallel_path(file_size, self.jobs) {
-            parallel_write::write_content(&temp, &header, self.jobs, self.write_threads)?
+            parallel_write::write_content(
+                &temp,
+                &header,
+                self.jobs,
+                self.write_threads,
+                Some(progress),
+            )?
         } else {
-            write_content_serial(&mut temp, &header, buffer)?
+            write_content_serial(&mut temp, &header, buffer, progress)?
         };
 
         let final_path = hash_to_path(&self.root, digest);
@@ -235,6 +274,7 @@ impl GeneratorBuilder {
                 sizes: SizeChooser::fixed(DEFAULT_FILE_SIZE),
                 jobs: default_jobs(),
                 write_threads: DEFAULT_WRITE_THREADS,
+                progress: None,
             },
         }
     }
@@ -294,6 +334,18 @@ impl GeneratorBuilder {
         self
     }
 
+    /// Reports byte and file progress while generation runs.
+    ///
+    /// The callback may run on any generation worker thread and should
+    /// return quickly. It receives an initial zero snapshot, updates after
+    /// content writes, and a snapshot after each completed file. Omitting a
+    /// callback has no effect on generated data or reports.
+    #[must_use]
+    pub fn progress(mut self, report: impl Fn(OperationProgress) + Send + Sync + 'static) -> Self {
+        self.generator.progress = Some(ProgressCallback::new(report));
+        self
+    }
+
     /// Writes parallel-generated content on `count` threads (default 4).
     ///
     /// Writer threads submit filled blocks to the operating system and
@@ -330,9 +382,10 @@ fn write_content_serial(
     temp: &mut TempFile,
     header: &Header,
     buffer: &mut [u8],
+    progress: &ProgressTracker,
 ) -> Result<Digest, GenerateError> {
     if header.format() == Format::V3 {
-        return write_v3_content_serial(temp, header, buffer);
+        return write_v3_content_serial(temp, header, buffer, progress);
     }
 
     let mut hasher = Hasher::new();
@@ -341,6 +394,7 @@ fn write_content_serial(
         .write_all(&encoded)
         .map_err(|source| GenerateError::io("writing the header", temp.path(), source))?;
     hasher.update(encoded);
+    progress.add_bytes(encoded.len() as u64);
 
     // One reusable block-sized buffer streams SHAKE generation, file
     // writing, and BLAKE2b hashing; the reader squeezes only the bytes
@@ -358,6 +412,7 @@ fn write_content_serial(
             .write_all(chunk)
             .map_err(|source| GenerateError::io("writing content", temp.path(), source))?;
         hasher.update(chunk);
+        progress.add_bytes(take as u64);
         remaining -= take as u64;
     }
     Ok(hasher.finalize())
@@ -368,6 +423,7 @@ fn write_v3_content_serial(
     temp: &mut TempFile,
     header: &Header,
     buffer: &mut [u8],
+    progress: &ProgressTracker,
 ) -> Result<Digest, GenerateError> {
     debug_assert_eq!(header.format(), Format::V3);
     let encoded = header.encode();
@@ -404,6 +460,7 @@ fn write_v3_content_serial(
         temp.file_mut()
             .write_all(block)
             .map_err(|source| GenerateError::io("writing content", temp.path(), source))?;
+        progress.add_bytes(len as u64);
     }
 
     Ok(Digest::from_bytes(

--- a/crates/caf-store/src/lib.rs
+++ b/crates/caf-store/src/lib.rs
@@ -60,6 +60,7 @@ mod metadata;
 mod parallel_verify;
 mod parallel_write;
 mod pipeline;
+mod progress;
 mod random;
 mod size;
 mod temp;
@@ -74,6 +75,8 @@ pub use env::MockCtrl;
 pub use generate::{
     DEFAULT_FILE_SIZE, GenerateError, GenerationReport, Generator, GeneratorBuilder,
 };
+#[doc(inline)]
+pub use progress::OperationProgress;
 #[doc(inline)]
 pub use size::{
     ParseSizeError, SampleError, SizeChooser, SizeSpec, SizeSpecError, parse_byte_size,

--- a/crates/caf-store/src/parallel_verify.rs
+++ b/crates/caf-store/src/parallel_verify.rs
@@ -23,6 +23,7 @@ use caf_format::{
 };
 
 use crate::env::FileHandle;
+use crate::progress::FileProgress;
 
 /// Buffers in flight per positional reader.
 const BUFFERS_PER_READER: usize = 4;
@@ -128,6 +129,7 @@ pub(crate) fn hash_file(
     header_bytes: &[u8],
     actual_size: u64,
     width: usize,
+    progress: Option<&FileProgress<'_>>,
 ) -> io::Result<Digest> {
     assert!(width >= 2, "parallel hashing needs a reader and a hasher");
     let content_start = header_bytes.len() as u64;
@@ -164,6 +166,7 @@ pub(crate) fn hash_file(
                         pool,
                         next_index,
                         &sender,
+                        progress,
                     );
                 }));
                 if let Err(payload) = worked {
@@ -306,6 +309,7 @@ pub(crate) fn hash_v3_file(
     actual_size: u64,
     width: usize,
     scratch: &mut ScanBuffers,
+    progress: Option<&FileProgress<'_>>,
 ) -> io::Result<V3HashResult> {
     debug_assert_eq!(header.format(), Format::V3);
     assert!(width >= 1, "a v3 file hash needs at least one lane");
@@ -319,20 +323,15 @@ pub(crate) fn hash_v3_file(
     let leaf_count = usize::try_from(total)
         .map_err(|_error| io::Error::new(io::ErrorKind::FileTooLarge, "too many v3 blocks"))?;
     if width == 1 {
-        let mut leaves = allocate_leaves(leaf_count)?;
-        let mut content_matches = true;
-        for index in 0..total {
-            let (leaf, block_content_matches) =
-                read_v3_block(file, header, actual_size, index, scratch)?;
-            let slot =
-                usize::try_from(index).expect("a block index fits because the leaf count does");
-            leaves[slot] = leaf;
-            content_matches &= block_content_matches;
-        }
-        return Ok(V3HashResult {
-            digest: Digest::from_bytes(v3_file_id_from_leaves(actual_size, leaves).into_inner()),
-            content_matches,
-        });
+        return hash_v3_serially(
+            file,
+            header,
+            actual_size,
+            total,
+            leaf_count,
+            scratch,
+            progress,
+        );
     }
 
     let results = V3Results::new(allocate_leaves(leaf_count)?);
@@ -356,6 +355,7 @@ pub(crate) fn hash_v3_file(
                         cancelled,
                         results,
                         &mut ScanBuffers::new(),
+                        progress,
                     );
                 }));
                 if let Err(payload) = worked {
@@ -380,6 +380,7 @@ pub(crate) fn hash_v3_file(
                 &cancelled,
                 &results,
                 scratch,
+                progress,
             );
         }));
         if let Err(payload) = worked {
@@ -405,6 +406,35 @@ pub(crate) fn hash_v3_file(
         .leaves
         .into_inner()
         .unwrap_or_else(PoisonError::into_inner);
+    Ok(V3HashResult {
+        digest: Digest::from_bytes(v3_file_id_from_leaves(actual_size, leaves).into_inner()),
+        content_matches,
+    })
+}
+
+/// Width-one [`hash_v3_file`] pass: reads, checks, and reports each
+/// block on the calling thread, with no worker threads or shared state.
+fn hash_v3_serially(
+    file: &FileHandle,
+    header: &Header,
+    actual_size: u64,
+    total: u64,
+    leaf_count: usize,
+    scratch: &mut ScanBuffers,
+    progress: Option<&FileProgress<'_>>,
+) -> io::Result<V3HashResult> {
+    let mut leaves = allocate_leaves(leaf_count)?;
+    let mut content_matches = true;
+    for index in 0..total {
+        let (leaf, block_content_matches) =
+            read_v3_block(file, header, actual_size, index, scratch)?;
+        if let Some(progress) = progress {
+            report_v3_block(progress, actual_size, index);
+        }
+        let slot = usize::try_from(index).expect("a block index fits because the leaf count does");
+        leaves[slot] = leaf;
+        content_matches &= block_content_matches;
+    }
     Ok(V3HashResult {
         digest: Digest::from_bytes(v3_file_id_from_leaves(actual_size, leaves).into_inner()),
         content_matches,
@@ -503,6 +533,7 @@ fn read_v3_blocks(
     cancelled: &AtomicBool,
     results: &V3Results,
     scratch: &mut ScanBuffers,
+    progress: Option<&FileProgress<'_>>,
 ) {
     while !cancelled.load(Ordering::Relaxed) {
         let index = next_index.fetch_add(1, Ordering::Relaxed);
@@ -511,6 +542,9 @@ fn read_v3_blocks(
         }
         match read_v3_block(file, header, actual_size, index, scratch) {
             Ok((leaf, block_content_matches)) => {
+                if let Some(progress) = progress {
+                    report_v3_block(progress, actual_size, index);
+                }
                 results.store(index, leaf, block_content_matches);
             }
             Err(source) => {
@@ -520,6 +554,15 @@ fn read_v3_blocks(
             }
         }
     }
+}
+
+/// Reports one hashed physical block, net of the header bytes the
+/// caller already counted before block 0 was read back.
+fn report_v3_block(progress: &FileProgress<'_>, actual_size: u64, index: u64) {
+    let offset = index * BLOCK_SIZE as u64;
+    let block_len = (actual_size - offset).min(BLOCK_SIZE as u64);
+    let already_counted = if index == 0 { HEADER_SIZE as u64 } else { 0 };
+    progress.add_bytes(block_len.saturating_sub(already_counted));
 }
 
 fn read_v3_block(
@@ -558,6 +601,10 @@ fn read_v3_block(
     Ok((v3_leaf_hash(index, block), content_matches))
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one reader's full segment plan; grouping would only rename it"
+)]
 fn read_segments<'pool>(
     file: &FileHandle,
     content_start: u64,
@@ -566,6 +613,7 @@ fn read_segments<'pool>(
     pool: &'pool Pool,
     next_index: &AtomicU64,
     sender: &SyncSender<Message<'pool>>,
+    progress: Option<&FileProgress<'_>>,
 ) {
     // Taking a buffer before claiming an index guarantees that the
     // lowest outstanding segment always has a reader and bounds claims
@@ -583,6 +631,9 @@ fn read_segments<'pool>(
         match file.read_full_at(&mut buffer.bytes, offset) {
             Ok(got) => {
                 buffer.bytes.truncate(got);
+                if let Some(progress) = progress {
+                    progress.add_bytes(got as u64);
+                }
                 if sender
                     .send(Message::Segment(Segment { index, buffer }))
                     .is_err()
@@ -750,12 +801,14 @@ mod mocked_tests {
     use std::io::{self, Read as _};
     use std::panic::{self, AssertUnwindSafe};
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
-    use caf_format::{BLOCK_SIZE, ContentSeed, Digest, FileId, Header};
+    use caf_format::{BLOCK_SIZE, ContentSeed, Digest, FileId, HEADER_SIZE, Header};
 
     use super::{ScanBuffers, hash_file, hash_v3_file};
     use crate::env::Env;
+    use crate::progress::{FileProgress, ProgressCallback, ProgressTracker};
 
     fn bytes(len: usize) -> Vec<u8> {
         (0..len)
@@ -776,10 +829,64 @@ mod mocked_tests {
         )
         .expect("the header length is valid");
 
-        let error = hash_v3_file(&file, &header, 59, 1, &mut ScanBuffers::new())
+        let error = hash_v3_file(&file, &header, 59, 1, &mut ScanBuffers::new(), None)
             .err()
             .expect("stale short metadata is rejected");
         assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    /// The width-one branch hashes on the calling thread and must report
+    /// each block as it is read, not leave the file at zero until the
+    /// caller's final `finish` jumps it to complete.
+    #[test]
+    fn v3_width_one_reports_progress_per_block() {
+        let size = 3 * BLOCK_SIZE as u64;
+        let (env, ctrl) = Env::mocked();
+        ctrl.write_file("/file", bytes(3 * BLOCK_SIZE))
+            .expect("the fixture is writable");
+        let file = env.open(Path::new("/file")).expect("the file opens");
+        let header = Header::new_v3(
+            FileId::ZERO,
+            ContentSeed::from_bytes(*b"parallel-verify!"),
+            size,
+        )
+        .expect("the header length is valid");
+
+        let snapshots = Arc::new(Mutex::new(Vec::new()));
+        let reported = Arc::clone(&snapshots);
+        let tracker = ProgressTracker::new(
+            Some(ProgressCallback::new(move |snapshot| {
+                reported
+                    .lock()
+                    .expect("callback lock")
+                    .push(snapshot.bytes_completed());
+            })),
+            Some(size),
+            Some(1),
+        );
+        let file_progress = FileProgress::new(&tracker, size);
+        hash_v3_file(
+            &file,
+            &header,
+            size,
+            1,
+            &mut ScanBuffers::new(),
+            Some(&file_progress),
+        )
+        .expect("the blocks read back");
+
+        // One update per physical block; block 0 is net of the header
+        // bytes the caller counts when it reads the header up front.
+        let block = BLOCK_SIZE as u64;
+        assert_eq!(
+            *snapshots.lock().expect("callback lock"),
+            [
+                0,
+                block - HEADER_SIZE as u64,
+                2 * block - HEADER_SIZE as u64,
+                3 * block - HEADER_SIZE as u64,
+            ]
+        );
     }
 
     #[test]
@@ -795,7 +902,7 @@ mod mocked_tests {
             file.read_exact(&mut header)
                 .expect("the header is readable");
 
-            let actual = hash_file(&file, &header, 4 * BLOCK_SIZE as u64 + 17, 4)
+            let actual = hash_file(&file, &header, 4 * BLOCK_SIZE as u64 + 17, 4, None)
                 .expect("parallel reads succeed");
             assert_eq!(actual, expected, "header length {header_len}");
         }
@@ -815,8 +922,8 @@ mod mocked_tests {
         ctrl.interrupt_next_read_at();
         ctrl.limit_next_read_at(17);
 
-        let actual =
-            hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 2).expect("parallel reads retry");
+        let actual = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 2, None)
+            .expect("parallel reads retry");
         assert_eq!(actual, expected);
     }
 
@@ -832,7 +939,7 @@ mod mocked_tests {
         file.read_exact(&mut header)
             .expect("the header is readable");
 
-        let actual = hash_file(&file, &header, BLOCK_SIZE as u64 + 17, 64)
+        let actual = hash_file(&file, &header, BLOCK_SIZE as u64 + 17, 64, None)
             .expect("more lanes than segments are harmless");
         assert_eq!(actual, expected);
     }
@@ -849,7 +956,7 @@ mod mocked_tests {
             .expect("the header is readable");
         ctrl.fail_read_at(BLOCK_SIZE as u64 + 100, io::ErrorKind::PermissionDenied);
 
-        let error = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 4)
+        let error = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 4, None)
             .expect_err("the injected read fails");
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
     }
@@ -867,7 +974,7 @@ mod mocked_tests {
             .expect("the header is readable");
         ctrl.delay_read_at(60, Duration::from_millis(30));
 
-        let actual = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3)
+        let actual = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3, None)
             .expect("out-of-order reads succeed");
         assert_eq!(actual, expected);
     }
@@ -886,7 +993,7 @@ mod mocked_tests {
         ctrl.fail_read_at(100, io::ErrorKind::PermissionDenied);
         ctrl.fail_read_at(BLOCK_SIZE as u64 + 100, io::ErrorKind::StorageFull);
 
-        let error = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3)
+        let error = hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3, None)
             .expect_err("both initial segments fail");
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
     }
@@ -904,7 +1011,7 @@ mod mocked_tests {
         ctrl.panic_read_at(BLOCK_SIZE as u64 + 100);
 
         let payload = panic::catch_unwind(AssertUnwindSafe(|| {
-            hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3)
+            hash_file(&file, &header, 4 * BLOCK_SIZE as u64, 3, None)
         }))
         .expect_err("the reader panic reaches the coordinator");
         assert_eq!(

--- a/crates/caf-store/src/parallel_write.rs
+++ b/crates/caf-store/src/parallel_write.rs
@@ -34,6 +34,7 @@ use std::collections::BTreeMap;
 use std::io;
 use std::mem;
 use std::num::NonZeroUsize;
+use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
@@ -46,6 +47,7 @@ use caf_format::{
 
 use crate::env::FileHandle;
 use crate::generate::GenerateError;
+use crate::progress::ProgressTracker;
 use crate::temp::TempFile;
 
 /// Buffers the pool holds per generator thread.
@@ -87,6 +89,7 @@ pub(crate) fn write_content(
     header: &Header,
     jobs: NonZeroUsize,
     write_threads: NonZeroUsize,
+    progress: Option<&ProgressTracker>,
 ) -> Result<Digest, GenerateError> {
     let plan = Plan::new(header);
     let generators = thread_count(jobs, plan.blocks);
@@ -102,7 +105,7 @@ pub(crate) fn write_content(
         buffer_count(generators, writers, plan.blocks),
         plan.buffer_capacity(),
     );
-    run(temp.file(), &plan, &pool, generators, writers)
+    run(temp.file(), &plan, &pool, generators, writers, progress)
         .map_err(|source| GenerateError::io("writing content", temp.path(), source))
 }
 
@@ -116,10 +119,11 @@ fn run(
     pool: &Pool,
     generators: usize,
     writers: usize,
+    progress: Option<&ProgressTracker>,
 ) -> Result<Digest, io::Error> {
     match plan.format {
-        Format::V2 => run_v2(file, plan, pool, generators, writers),
-        Format::V3 => run_v3(file, plan, pool, generators, writers),
+        Format::V2 => run_v2(file, plan, pool, generators, writers, progress),
+        Format::V3 => run_v3(file, plan, pool, generators, writers, progress),
     }
 }
 
@@ -130,8 +134,10 @@ fn run_v2(
     pool: &Pool,
     generators: usize,
     writers: usize,
+    progress: Option<&ProgressTracker>,
 ) -> Result<Digest, io::Error> {
     let failure = ErrorSlot::new();
+    let panicked = PanicSlot::new();
     let next_index = AtomicU64::new(0);
     let (hash_tx, hash_rx) = mpsc::channel();
     let (write_tx, write_rx) = mpsc::channel();
@@ -165,7 +171,9 @@ fn run_v2(
                 break;
             }
             spawned = thread::Builder::new()
-                .spawn_scoped(scope, || write(file, &write_rx, pool, &failure))
+                .spawn_scoped(scope, || {
+                    write(file, &write_rx, pool, &failure, &panicked, progress);
+                })
                 .map(drop);
         }
         // The generators hold the only remaining senders, so both queues
@@ -181,16 +189,21 @@ fn run_v2(
     });
 
     // The scope has joined the writers, so every write that was going to
-    // happen has happened. A failure outranks a completed hash: the
-    // hasher only reads buffers and can finish while a write is still
-    // failing, and a file is correct only once every block reaches the
-    // disk.
+    // happen has happened. A recorded panic resumes first — it is the
+    // caller's own callback unwinding, not a result to report — then a
+    // failure outranks a completed hash: the hasher only reads buffers
+    // and can finish while a write is still failing, and a file is
+    // correct only once every block reaches the disk.
+    if let Some(payload) = panicked.take() {
+        panic::resume_unwind(payload);
+    }
     if let Some(source) = failure.take() {
         return Err(source);
     }
     // The block stream ends early only when a cancellation cuts it
-    // short, and both causes — a failed write, a refused spawn — have
-    // returned above; a generator panic unwinds through the scope.
+    // short, and every cause — a failed write, a refused spawn, a
+    // panicking writer — has returned or resumed above; a generator
+    // panic unwinds through the scope.
     Ok(hashed?.expect("the block stream ends early only after a cancellation"))
 }
 
@@ -201,8 +214,10 @@ fn run_v3(
     pool: &Pool,
     generators: usize,
     writers: usize,
+    progress: Option<&ProgressTracker>,
 ) -> Result<Digest, io::Error> {
     let failure = ErrorSlot::new();
+    let panicked = PanicSlot::new();
     let next_index = AtomicU64::new(0);
     let completed = AtomicU64::new(0);
     let leaves = Mutex::new(allocate_leaves(plan.blocks)?);
@@ -230,7 +245,9 @@ fn run_v3(
                 break;
             }
             spawned = thread::Builder::new()
-                .spawn_scoped(scope, || write(file, &write_rx, pool, &failure))
+                .spawn_scoped(scope, || {
+                    write(file, &write_rx, pool, &failure, &panicked, progress);
+                })
                 .map(drop);
         }
         drop(write_tx);
@@ -241,6 +258,9 @@ fn run_v3(
         spawned
     });
 
+    if let Some(payload) = panicked.take() {
+        panic::resume_unwind(payload);
+    }
     if let Some(source) = failure.take() {
         return Err(source);
     }
@@ -414,15 +434,36 @@ fn write(
     queue: &Mutex<Receiver<Arc<Block<'_>>>>,
     pool: &Pool,
     failure: &ErrorSlot,
+    panicked: &PanicSlot,
+    progress: Option<&ProgressTracker>,
 ) {
-    while let Ok(block) = next_block(queue) {
-        if failure.outranks(block.index) {
-            continue;
+    // The progress callback is caller code and may panic. An unwinding
+    // writer stops draining the queue, and without a cancellation the
+    // generators would wait forever on a pool the retained blocks never
+    // refill, deadlocking the scope's implicit join. So the panic is
+    // caught, the pool cancelled, and the payload recorded; the caller
+    // resumes the unwind once the scope has drained out.
+    let worked = panic::catch_unwind(AssertUnwindSafe(|| {
+        while let Ok(block) = next_block(queue) {
+            if failure.outranks(block.index) {
+                continue;
+            }
+            match file.write_all_at(block.bytes(), block.offset) {
+                Ok(()) => {
+                    if let Some(progress) = progress {
+                        progress.add_bytes(block.bytes().len() as u64);
+                    }
+                }
+                Err(source) => {
+                    failure.record(block.index, source);
+                    pool.cancel();
+                }
+            }
         }
-        if let Err(source) = file.write_all_at(block.bytes(), block.offset) {
-            failure.record(block.index, source);
-            pool.cancel();
-        }
+    }));
+    if let Err(payload) = worked {
+        pool.cancel();
+        panicked.record(payload);
     }
 }
 
@@ -555,6 +596,37 @@ impl Pool {
     }
 }
 
+/// The first writer panic, held until the caller can resume it.
+///
+/// A writer's scoped join handle is dropped at spawn, so a panic that
+/// unwound out of the thread would surface from the scope as a generic
+/// payload. Recording it here lets the caller resume the original one.
+struct PanicSlot {
+    slot: Mutex<Option<Box<dyn std::any::Any + Send>>>,
+}
+
+impl PanicSlot {
+    fn new() -> Self {
+        Self {
+            slot: Mutex::new(None),
+        }
+    }
+
+    fn record(&self, payload: Box<dyn std::any::Any + Send>) {
+        let mut slot = self.slot.lock().unwrap_or_else(PoisonError::into_inner);
+        if slot.is_none() {
+            *slot = Some(payload);
+        }
+    }
+
+    fn take(&self) -> Option<Box<dyn std::any::Any + Send>> {
+        self.slot
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take()
+    }
+}
+
 /// The write failure a run reports.
 ///
 /// Keeping the lowest block index makes the reported error the one a
@@ -600,6 +672,7 @@ impl ErrorSlot {
 mod tests {
     use std::io::{self, Read as _, Write as _};
     use std::num::NonZeroUsize;
+    use std::panic::{self, AssertUnwindSafe};
     use std::path::Path;
 
     use caf_format::{
@@ -612,6 +685,7 @@ mod tests {
         buffer_count, run, thread_count, total_blocks, write_content,
     };
     use crate::env::{Env, MockCtrl};
+    use crate::progress::{ProgressCallback, ProgressTracker};
     use crate::temp::TempFile;
 
     /// Sizes that exercise every block boundary the writer has to get
@@ -655,7 +729,7 @@ mod tests {
     fn write_parallel(header: &Header, threads: usize) -> (Digest, Vec<u8>) {
         let (_env, ctrl) = Env::mocked();
         let temp = temp_in_store(&ctrl);
-        let digest = write_content(&temp, header, jobs(threads), jobs(threads))
+        let digest = write_content(&temp, header, jobs(threads), jobs(threads), None)
             .expect("the mocked writes succeed");
         let bytes = ctrl.read_file(temp.path()).expect("the file is readable");
         (digest, bytes)
@@ -850,7 +924,7 @@ mod tests {
         let (_env, ctrl) = Env::mocked();
         let temp = temp_in_store(&ctrl);
         let pool = Pool::new(buffers, plan.buffer_capacity());
-        run(temp.file(), &plan, &pool, 4, 2).expect("the mocked writes succeed");
+        run(temp.file(), &plan, &pool, 4, 2, None).expect("the mocked writes succeed");
         assert_eq!(pool.free(), buffers, "after a successful run");
 
         // Failing every write cancels the run partway through.
@@ -860,7 +934,7 @@ mod tests {
         ctrl.fail_write_at(3 * BLOCK_SIZE as u64, io::ErrorKind::StorageFull);
         ctrl.fail_write_at(4 * BLOCK_SIZE as u64, io::ErrorKind::StorageFull);
         let pool = Pool::new(buffers, plan.buffer_capacity());
-        let err = run(temp.file(), &plan, &pool, 4, 2).expect_err("every write fails");
+        let err = run(temp.file(), &plan, &pool, 4, 2, None).expect_err("every write fails");
         assert_eq!(err.kind(), io::ErrorKind::StorageFull);
         assert_eq!(pool.free(), buffers, "after a cancelled run");
     }
@@ -881,7 +955,7 @@ mod tests {
             ctrl.fail_write_at(BLOCK_SIZE as u64, io::ErrorKind::PermissionDenied);
             ctrl.fail_write_at(3 * BLOCK_SIZE as u64, io::ErrorKind::StorageFull);
             let pool = Pool::new(buffer_count(4, 4, plan.blocks), plan.buffer_capacity());
-            let err = run(temp.file(), &plan, &pool, 4, 4).expect_err("two writes fail");
+            let err = run(temp.file(), &plan, &pool, 4, 4, None).expect_err("two writes fail");
             assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
         }
     }
@@ -900,12 +974,43 @@ mod tests {
         assert!(slot.take().is_none(), "the slot is emptied by take");
     }
 
+    /// A panicking progress callback unwinds the only writer. The writer
+    /// must cancel the pool on its way out, or the generators would wait
+    /// forever on buffers held by the undrained queue and this test
+    /// would hang instead of observing the panic.
+    #[test]
+    fn a_panicking_progress_callback_cancels_the_run() {
+        let (_env, ctrl) = Env::mocked();
+        let temp = temp_in_store(&ctrl);
+        // The tracker reports a zero-byte snapshot at construction; only
+        // the first written block trips the panic.
+        let tracker = ProgressTracker::new(
+            Some(ProgressCallback::new(|progress| {
+                assert!(
+                    progress.bytes_completed() == 0,
+                    "the progress callback panicked"
+                );
+            })),
+            None,
+            None,
+        );
+        let header = header_for(8 * BLOCK_SIZE as u64);
+        let payload = panic::catch_unwind(AssertUnwindSafe(|| {
+            write_content(&temp, &header, jobs(4), jobs(1), Some(&tracker))
+        }))
+        .expect_err("the callback panic reaches the caller");
+        assert_eq!(
+            payload.downcast_ref::<&str>(),
+            Some(&"the progress callback panicked")
+        );
+    }
+
     #[test]
     fn a_failed_preallocation_is_reported_with_the_temporary_path() {
         let (_env, ctrl) = Env::mocked();
         let temp = temp_in_store(&ctrl);
         ctrl.fail_set_len(io::ErrorKind::StorageFull);
-        let err = write_content(&temp, &header_for(4096), jobs(4), jobs(2))
+        let err = write_content(&temp, &header_for(4096), jobs(4), jobs(2), None)
             .expect_err("preallocation fails");
         assert!(err.is_io());
         assert_eq!(err.path(), Some(temp.path()));
@@ -924,8 +1029,14 @@ mod tests {
         let temp = temp_in_store(&ctrl);
         // Fail a block in the middle of the file, not the first one.
         ctrl.fail_write_at(2 * BLOCK_SIZE as u64, io::ErrorKind::PermissionDenied);
-        let err = write_content(&temp, &header_for(4 * BLOCK_SIZE as u64), jobs(4), jobs(2))
-            .expect_err("the write fails");
+        let err = write_content(
+            &temp,
+            &header_for(4 * BLOCK_SIZE as u64),
+            jobs(4),
+            jobs(2),
+            None,
+        )
+        .expect_err("the write fails");
         assert!(err.is_io());
         assert_eq!(err.path(), Some(temp.path()));
     }

--- a/crates/caf-store/src/progress.rs
+++ b/crates/caf-store/src/progress.rs
@@ -1,0 +1,231 @@
+//! Operation progress callbacks shared by generation and verification.
+
+use std::fmt::{self, Debug, Formatter};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+
+/// A point-in-time snapshot of generation or verification progress.
+///
+/// Byte and file totals are present when the operation knows them. For
+/// generation with sampled file sizes, a byte total may be the configured
+/// disk-usage stopping limit rather than the exact final size; the final file
+/// is allowed to overshoot that limit. All values are monotonically
+/// nondecreasing except that no total is inferred when it is unknowable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct OperationProgress {
+    bytes_completed: u64,
+    total_bytes: Option<u64>,
+    files_completed: u64,
+    total_files: Option<u64>,
+}
+
+impl OperationProgress {
+    /// Bytes written or checked so far.
+    #[must_use]
+    pub fn bytes_completed(self) -> u64 {
+        self.bytes_completed
+    }
+
+    /// Total bytes expected, or a generation disk-usage limit when exact
+    /// output size is unknowable.
+    #[must_use]
+    pub fn total_bytes(self) -> Option<u64> {
+        self.total_bytes
+    }
+
+    /// Files fully written or checked so far.
+    #[must_use]
+    pub fn files_completed(self) -> u64 {
+        self.files_completed
+    }
+
+    /// Total files expected, when known.
+    #[must_use]
+    pub fn total_files(self) -> Option<u64> {
+        self.total_files
+    }
+}
+
+/// A thread-safe callback configured by an operation's builder.
+#[derive(Clone)]
+pub(crate) struct ProgressCallback(Arc<dyn Fn(OperationProgress) + Send + Sync>);
+
+impl ProgressCallback {
+    pub(crate) fn new(report: impl Fn(OperationProgress) + Send + Sync + 'static) -> Self {
+        Self(Arc::new(report))
+    }
+
+    fn report(&self, progress: OperationProgress) {
+        (self.0)(progress);
+    }
+}
+
+impl Debug for ProgressCallback {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("ProgressCallback")
+    }
+}
+
+/// Shared counters behind one operation's worker threads.
+#[derive(Debug)]
+pub(crate) struct ProgressTracker {
+    callback: Option<ProgressCallback>,
+    bytes_completed: AtomicU64,
+    total_bytes: Option<u64>,
+    files_completed: AtomicU64,
+    total_files: Option<u64>,
+    reporting: Mutex<()>,
+}
+
+impl ProgressTracker {
+    pub(crate) fn new(
+        callback: Option<ProgressCallback>,
+        total_bytes: Option<u64>,
+        total_files: Option<u64>,
+    ) -> Self {
+        let tracker = Self {
+            callback,
+            bytes_completed: AtomicU64::new(0),
+            total_bytes,
+            files_completed: AtomicU64::new(0),
+            total_files,
+            reporting: Mutex::new(()),
+        };
+        tracker.report();
+        tracker
+    }
+
+    pub(crate) fn enabled(&self) -> bool {
+        self.callback.is_some()
+    }
+
+    pub(crate) fn add_bytes(&self, bytes: u64) {
+        if bytes == 0 || !self.enabled() {
+            return;
+        }
+        saturating_add(&self.bytes_completed, bytes);
+        self.report();
+    }
+
+    pub(crate) fn finish_file(&self) {
+        if !self.enabled() {
+            return;
+        }
+        saturating_add(&self.files_completed, 1);
+        self.report();
+    }
+
+    fn report(&self) {
+        if let Some(callback) = &self.callback {
+            // Worker updates race, but callback delivery must not: otherwise
+            // an older snapshot could arrive after a newer one and make a
+            // terminal progress bar jump backwards.
+            let _reporting = self
+                .reporting
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            callback.report(OperationProgress {
+                bytes_completed: self.bytes_completed.load(Ordering::Relaxed),
+                total_bytes: self.total_bytes,
+                files_completed: self.files_completed.load(Ordering::Relaxed),
+                total_files: self.total_files,
+            });
+        }
+    }
+}
+
+/// Adds without wrapping at the edge of the counter's range.
+fn saturating_add(counter: &AtomicU64, amount: u64) {
+    let _previous = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(amount))
+    });
+}
+
+/// Caps one file's contributions so a second analysis/read pass never makes
+/// operation progress exceed the file's on-disk size.
+#[derive(Debug)]
+pub(crate) struct FileProgress<'tracker> {
+    tracker: &'tracker ProgressTracker,
+    file_size: u64,
+    bytes_completed: AtomicU64,
+}
+
+impl<'tracker> FileProgress<'tracker> {
+    pub(crate) fn new(tracker: &'tracker ProgressTracker, file_size: u64) -> Self {
+        Self {
+            tracker,
+            file_size,
+            bytes_completed: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn add_bytes(&self, bytes: u64) {
+        if bytes == 0 || !self.tracker.enabled() {
+            return;
+        }
+        let mut added = 0;
+        let _previous =
+            self.bytes_completed
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                    let next = current.saturating_add(bytes).min(self.file_size);
+                    added = next - current;
+                    Some(next)
+                });
+        self.tracker.add_bytes(added);
+    }
+
+    pub(crate) fn finish(&self) {
+        if !self.tracker.enabled() {
+            return;
+        }
+        let completed = self.bytes_completed.swap(self.file_size, Ordering::Relaxed);
+        self.tracker
+            .add_bytes(self.file_size.saturating_sub(completed));
+        self.tracker.finish_file();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::{FileProgress, ProgressCallback, ProgressTracker};
+
+    #[test]
+    fn snapshots_are_monotonic_and_file_reads_are_capped() {
+        let snapshots = Arc::new(Mutex::new(Vec::new()));
+        let reported = Arc::clone(&snapshots);
+        let tracker = ProgressTracker::new(
+            Some(ProgressCallback::new(move |snapshot| {
+                reported.lock().expect("callback lock").push(snapshot);
+            })),
+            Some(100),
+            Some(1),
+        );
+        let file = FileProgress::new(&tracker, 100);
+        file.add_bytes(60);
+        file.add_bytes(100);
+        file.finish();
+
+        let snapshots = snapshots.lock().expect("callback lock");
+        assert_eq!(snapshots[0].bytes_completed(), 0);
+        assert_eq!(
+            snapshots
+                .last()
+                .expect("a final snapshot")
+                .bytes_completed(),
+            100
+        );
+        assert_eq!(
+            snapshots
+                .last()
+                .expect("a final snapshot")
+                .files_completed(),
+            1
+        );
+        assert!(snapshots.windows(2).all(|pair| {
+            pair[0].bytes_completed() <= pair[1].bytes_completed()
+                && pair[0].files_completed() <= pair[1].files_completed()
+        }));
+    }
+}

--- a/crates/caf-store/src/size.rs
+++ b/crates/caf-store/src/size.rs
@@ -455,6 +455,18 @@ impl SizeChooser {
         }
     }
 
+    /// Returns the one size this chooser always selects, when it is fixed.
+    pub(crate) fn fixed_size(&self) -> Option<u64> {
+        match &self.kind {
+            ChooserKind::Fixed(bytes) => Some(*bytes),
+            ChooserKind::Range { .. }
+            | ChooserKind::Normal { .. }
+            | ChooserKind::Gamma { .. }
+            | ChooserKind::LogNormal { .. }
+            | ChooserKind::Custom(_) => None,
+        }
+    }
+
     /// Returns the size in bytes for the next file.
     ///
     /// # Errors

--- a/crates/caf-store/src/verify.rs
+++ b/crates/caf-store/src/verify.rs
@@ -43,6 +43,7 @@ use caf_format::{
 use crate::analysis::{self, CorruptionReport, read_full};
 use crate::env::{DirEntry, Env, FileHandle};
 use crate::metadata::{ALL_FILE, METADATA_DIR, ROOTS_DIR};
+use crate::progress::{FileProgress, OperationProgress, ProgressCallback, ProgressTracker};
 use crate::{MAX_JOBS, default_jobs, parallel_verify, pipeline};
 
 /// Default corruption-analysis chunk size in bytes.
@@ -93,6 +94,7 @@ pub struct Verifier {
     root: PathBuf,
     analysis_chunk_size: NonZeroUsize,
     jobs: NonZeroUsize,
+    progress: Option<ProgressCallback>,
 }
 
 impl Verifier {
@@ -123,6 +125,7 @@ impl Verifier {
             root: root.into(),
             analysis_chunk_size: DEFAULT_ANALYSIS_CHUNK_SIZE,
             jobs: default_jobs(),
+            progress: None,
         }
     }
 
@@ -159,6 +162,19 @@ impl Verifier {
     #[must_use]
     pub fn jobs(mut self, count: NonZeroUsize) -> Self {
         self.jobs = count.min(MAX_JOBS);
+        self
+    }
+
+    /// Reports byte and file progress while verification runs.
+    ///
+    /// The callback may run on any verification worker thread and should
+    /// return quickly. It receives an initial zero snapshot, block-level
+    /// updates while large files are read, and a snapshot after each
+    /// completed file. Omitting a callback does not add a preliminary file
+    /// size scan and has no effect on the report.
+    #[must_use]
+    pub fn progress(mut self, report: impl Fn(OperationProgress) + Send + Sync + 'static) -> Self {
+        self.progress = Some(ProgressCallback::new(report));
         self
     }
 
@@ -199,16 +215,30 @@ impl Verifier {
 
         let files = collect_data_files(&self.env, &self.root)?;
         let files_checked = files.len() as u64;
+        let total_bytes = self.progress.as_ref().map(|_callback| {
+            files.iter().fold(0_u64, |total, path| {
+                let size = self.env.metadata(path).map_or(0, crate::env::Metadata::len);
+                total.saturating_add(size)
+            })
+        });
+        let progress =
+            ProgressTracker::new(self.progress.clone(), total_bytes, Some(files_checked));
         let mut checks = StoreChecks::new(files.len());
         let analysis_memory = analysis::AnalysisMemory::new();
 
         if self.jobs == NonZeroUsize::MIN {
             let mut scratch = parallel_verify::ScanBuffers::new();
             for path in files {
-                checks.absorb(self.validate_file(path, 1, &mut scratch, &analysis_memory)?);
+                checks.absorb(self.validate_file(
+                    path,
+                    1,
+                    &mut scratch,
+                    &analysis_memory,
+                    &progress,
+                )?);
             }
         } else {
-            self.validate_files_parallel(&files, &mut checks, &analysis_memory)?;
+            self.validate_files_parallel(&files, &mut checks, &analysis_memory, &progress)?;
         }
 
         let mut diagnostics = checks.into_diagnostics(&marker_set, &self.root);
@@ -235,14 +265,15 @@ impl Verifier {
         files: &[PathBuf],
         checks: &mut StoreChecks,
         analysis_memory: &analysis::AnalysisMemory,
+        progress: &ProgressTracker,
     ) -> Result<(), VerifyError> {
         let jobs = self.jobs.get();
         let contended = parallel_verify::contended_prefix_len(files.len(), jobs);
 
         if contended > 0 {
-            self.validate_contended_files(&files[..contended], checks, analysis_memory)?;
+            self.validate_contended_files(&files[..contended], checks, analysis_memory, progress)?;
         }
-        self.validate_tail_files(&files[contended..], checks, analysis_memory)
+        self.validate_tail_files(&files[contended..], checks, analysis_memory, progress)
     }
 
     /// The existing file-level regime: fixed workers, no length planning,
@@ -252,6 +283,7 @@ impl Verifier {
         files: &[PathBuf],
         checks: &mut StoreChecks,
         analysis_memory: &analysis::AnalysisMemory,
+        progress: &ProgressTracker,
     ) -> Result<(), VerifyError> {
         pipeline::run(
             files.len(),
@@ -259,7 +291,13 @@ impl Verifier {
             || {
                 let mut scratch = parallel_verify::ScanBuffers::new();
                 move |index: usize| {
-                    self.validate_file(files[index].clone(), 1, &mut scratch, analysis_memory)
+                    self.validate_file(
+                        files[index].clone(),
+                        1,
+                        &mut scratch,
+                        analysis_memory,
+                        progress,
+                    )
                 }
             },
             |outcome| checks.absorb(outcome),
@@ -275,6 +313,7 @@ impl Verifier {
         files: &[PathBuf],
         checks: &mut StoreChecks,
         analysis_memory: &analysis::AnalysisMemory,
+        progress: &ProgressTracker,
     ) -> Result<(), VerifyError> {
         if files.is_empty() {
             return Ok(());
@@ -302,6 +341,7 @@ impl Verifier {
                     widths[index],
                     &mut scratch,
                     analysis_memory,
+                    progress,
                 )
             }));
             let message = match result {
@@ -358,16 +398,33 @@ impl Verifier {
     /// Validates one data file and returns everything it contributes to
     /// the report. Self-contained per file, so serial and parallel runs
     /// produce identical outcomes.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one linear validation pipeline with shared early outcomes"
+    )]
     fn validate_file(
         &self,
         path: PathBuf,
         width: usize,
         scratch: &mut parallel_verify::ScanBuffers,
         analysis_memory: &analysis::AnalysisMemory,
+        progress: &ProgressTracker,
     ) -> Result<FileOutcome, VerifyError> {
         let mut diagnostics = Vec::new();
         let Ok(digest_from_path) = parse_hash_from_path(&path) else {
             diagnostics.push(Diagnostic::InvalidPathLayout { path: path.clone() });
+            // The preliminary scan counted this file's size in the byte
+            // total, so its bytes complete along with its file: a large
+            // stray file must not hold the reported bytes short of the
+            // total for the whole run.
+            if progress.enabled() {
+                let size = self
+                    .env
+                    .metadata(&path)
+                    .map_or(0, crate::env::Metadata::len);
+                progress.add_bytes(size);
+            }
+            progress.finish_file();
             return Ok(FileOutcome {
                 record: FileRecord {
                     path,
@@ -389,10 +446,12 @@ impl Verifier {
             .metadata()
             .map_err(|source| VerifyError::io("reading data-file metadata", &path, source))?
             .len();
+        let file_progress = FileProgress::new(progress, actual_size);
 
         let mut header_bytes = [0_u8; HEADER_SIZE];
         let header_len = read_full(&mut file, &mut header_bytes)
             .map_err(|source| VerifyError::io("reading a data-file header", &path, source))?;
+        file_progress.add_bytes(header_len as u64);
         let header = match Header::parse(&header_bytes[..header_len]) {
             Ok(header) => header,
             Err(source) => {
@@ -400,6 +459,7 @@ impl Verifier {
                     path: path.clone(),
                     source,
                 });
+                file_progress.finish();
                 return Ok(FileOutcome {
                     record: FileRecord {
                         path,
@@ -432,6 +492,7 @@ impl Verifier {
             actual_size,
             width,
             scratch,
+            &file_progress,
         )
         .map_err(|source| VerifyError::io("reading a data file", &path, source))?;
 
@@ -464,6 +525,7 @@ impl Verifier {
         } else {
             Some(header.parent())
         };
+        file_progress.finish();
         Ok(FileOutcome {
             record: FileRecord {
                 path,
@@ -512,24 +574,31 @@ fn hash_validated_file(
     actual_size: u64,
     width: usize,
     scratch: &mut parallel_verify::ScanBuffers,
+    progress: &FileProgress<'_>,
 ) -> io::Result<(Digest, bool)> {
     match header.format() {
         Format::V2 => {
             let digest = if width >= 2 {
-                parallel_verify::hash_file(file, header_bytes, actual_size, width)
+                parallel_verify::hash_file(file, header_bytes, actual_size, width, Some(progress))
             } else {
                 // A previous v3 file may have left the block buffer
                 // shorter; whole-file reads want the full block.
                 if scratch.block.len() < BLOCK_SIZE {
                     scratch.block.resize(BLOCK_SIZE, 0);
                 }
-                hash_whole_file(file, header_bytes, &mut scratch.block)
+                hash_whole_file(file, header_bytes, &mut scratch.block, Some(progress))
             }?;
             Ok((digest, true))
         }
         Format::V3 => {
-            let result =
-                parallel_verify::hash_v3_file(file, header, actual_size, width.max(1), scratch)?;
+            let result = parallel_verify::hash_v3_file(
+                file,
+                header,
+                actual_size,
+                width.max(1),
+                scratch,
+                Some(progress),
+            )?;
             Ok((result.digest, result.content_matches))
         }
     }
@@ -713,6 +782,7 @@ fn hash_whole_file(
     mut file: impl Read,
     header_bytes: &[u8],
     buffer: &mut [u8],
+    progress: Option<&FileProgress<'_>>,
 ) -> io::Result<Digest> {
     let mut hasher = Hasher::new();
     hasher.update(header_bytes);
@@ -724,6 +794,9 @@ fn hash_whole_file(
             Err(err) => return Err(err),
         };
         hasher.update(&buffer[..n]);
+        if let Some(progress) = progress {
+            progress.add_bytes(n as u64);
+        }
     }
     Ok(hasher.finalize())
 }

--- a/crates/caf-store/tests/generation.rs
+++ b/crates/caf-store/tests/generation.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::io::Read as _;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use caf_format::{
     BLOCK_SIZE, ContentReader, Digest, FileId, Format, HEADER_SIZE, Hasher, Header,
@@ -248,6 +249,43 @@ fn parallel_generation_produces_a_structurally_valid_store() {
         );
     }
     check_store(store.path());
+}
+
+#[test]
+fn parallel_generation_reports_exact_monotonic_progress() {
+    let store = tempfile::tempdir().expect("create temp store");
+    let file_size = 8 * BLOCK_SIZE as u64;
+    let snapshots = Arc::new(Mutex::new(Vec::new()));
+    let reported = Arc::clone(&snapshots);
+
+    Generator::builder(store.path())
+        .max_files(2)
+        .file_sizes(SizeChooser::fixed(file_size))
+        .jobs(NonZeroUsize::new(4).expect("four workers"))
+        .progress(move |snapshot| {
+            reported.lock().expect("progress log").push(snapshot);
+        })
+        .build()
+        .generate()
+        .expect("generation succeeds");
+
+    let snapshots = snapshots.lock().expect("progress log");
+    let first = snapshots.first().expect("an initial snapshot");
+    assert_eq!(first.bytes_completed(), 0);
+    assert_eq!(first.files_completed(), 0);
+    assert_eq!(first.total_bytes(), Some(2 * file_size));
+    assert_eq!(first.total_files(), Some(2));
+    let last = snapshots.last().expect("a final snapshot");
+    assert_eq!(last.bytes_completed(), 2 * file_size);
+    assert_eq!(last.files_completed(), 2);
+    assert!(
+        snapshots.len() > 4,
+        "large files report block-level updates"
+    );
+    assert!(snapshots.windows(2).all(|pair| {
+        pair[0].bytes_completed() <= pair[1].bytes_completed()
+            && pair[0].files_completed() <= pair[1].files_completed()
+    }));
 }
 
 #[test]

--- a/crates/caf-store/tests/verification.rs
+++ b/crates/caf-store/tests/verification.rs
@@ -9,6 +9,7 @@ use std::fs::{self, OpenOptions};
 use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use caf_format::{
     BLOCK_SIZE, ContentReader, ContentSeed, Digest, FileId, Format, HEADER_SIZE, Hasher, Header,
@@ -1282,6 +1283,74 @@ fn parallel_verification_matches_serial_on_a_clean_store() {
     for jobs in [1, 2, 4, 8] {
         assert_matches_serial(store.path(), &serial, jobs);
     }
+}
+
+#[test]
+fn parallel_verification_reports_exact_monotonic_progress() {
+    let store = tempfile::tempdir().expect("create temp store");
+    let file_size = 4 * BLOCK_SIZE as u64;
+    generate(store.path(), 3, file_size);
+    let snapshots = Arc::new(Mutex::new(Vec::new()));
+    let reported = Arc::clone(&snapshots);
+
+    let report = Verifier::new(store.path())
+        .jobs(positive(4))
+        .progress(move |snapshot| {
+            reported.lock().expect("progress log").push(snapshot);
+        })
+        .verify()
+        .expect("verification runs");
+    assert!(report.success());
+
+    let snapshots = snapshots.lock().expect("progress log");
+    let first = snapshots.first().expect("an initial snapshot");
+    assert_eq!(first.bytes_completed(), 0);
+    assert_eq!(first.files_completed(), 0);
+    assert_eq!(first.total_bytes(), Some(3 * file_size));
+    assert_eq!(first.total_files(), Some(3));
+    let last = snapshots.last().expect("a final snapshot");
+    assert_eq!(last.bytes_completed(), 3 * file_size);
+    assert_eq!(last.files_completed(), 3);
+    assert!(
+        snapshots.len() > 5,
+        "large files report block-level updates"
+    );
+    assert!(snapshots.windows(2).all(|pair| {
+        pair[0].bytes_completed() <= pair[1].bytes_completed()
+            && pair[0].files_completed() <= pair[1].files_completed()
+    }));
+}
+
+/// A stray file whose path is not a store layout is counted by the
+/// preliminary byte total, so its bytes must also complete: otherwise a
+/// finished run would end short of 100% and skew percentages and ETAs
+/// throughout.
+#[test]
+fn stray_file_bytes_complete_the_progress_totals() {
+    let store = tempfile::tempdir().expect("create temp store");
+    let file_size = 512_u64;
+    generate(store.path(), 1, file_size);
+    let stray = store.path().join("leftover-temporary");
+    let stray_size = 4096_usize;
+    fs::write(&stray, vec![0x5A; stray_size]).expect("write the stray file");
+    let snapshots = Arc::new(Mutex::new(Vec::new()));
+    let reported = Arc::clone(&snapshots);
+
+    let report = Verifier::new(store.path())
+        .progress(move |snapshot| {
+            reported.lock().expect("progress log").push(snapshot);
+        })
+        .verify()
+        .expect("verification runs");
+    assert!(!report.success(), "the stray file is diagnosed");
+
+    let snapshots = snapshots.lock().expect("progress log");
+    let last = snapshots.last().expect("a final snapshot");
+    let total = file_size + stray_size as u64;
+    assert_eq!(last.total_bytes(), Some(total));
+    assert_eq!(last.bytes_completed(), total);
+    assert_eq!(last.total_files(), Some(2));
+    assert_eq!(last.files_completed(), 2);
 }
 
 #[test]

--- a/crates/caf/src/generate.rs
+++ b/crates/caf/src/generate.rs
@@ -5,17 +5,21 @@
 //! file size is 4,096 bytes; sizes below the 60-byte header are clamped
 //! up by the library. `--jobs` defaults to a CPU-aware worker budget and
 //! rejects values below one; it changes only how fast a large file is
-//! written, never what is written. `gen` prints nothing on success.
+//! written, never what is written. `gen` shows live progress when
+//! standard error is a terminal and prints nothing when output is
+//! redirected.
 
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
 use caf_format::Format;
 use caf_store::{Generator, ParseSizeError, SizeSpec, default_jobs, parse_byte_size};
 
 use crate::EXIT_FAILURE;
+use crate::progress::{Basis, ProgressBar};
 use crate::util::StoreRoot;
 
 /// Files generated when neither stopping option is given.
@@ -180,10 +184,14 @@ fn parse_file_size(value: &str) -> Result<SizeSpec, ParseSizeError> {
 
 /// Runs `caf gen`.
 pub fn run(args: &Args) -> ExitCode {
-    match generate(args) {
-        // Successful generation produces no output.
-        Ok(()) => ExitCode::SUCCESS,
+    let progress = ProgressBar::new("Generate", Basis::AnyLimit);
+    match generate(args, &progress) {
+        Ok(()) => {
+            progress.finish(true);
+            ExitCode::SUCCESS
+        }
         Err(err) => {
+            progress.clear();
             eprintln!("error: {err:#}");
             ExitCode::from(EXIT_FAILURE)
         }
@@ -191,7 +199,7 @@ pub fn run(args: &Args) -> ExitCode {
 }
 
 /// Generates the chain `args` describes.
-fn generate(args: &Args) -> Result<()> {
+fn generate(args: &Args, progress: &Arc<ProgressBar>) -> Result<()> {
     let directory = StoreRoot::from(args.directory.as_deref()).resolve()?;
     let mut builder = Generator::builder(directory);
 
@@ -218,11 +226,14 @@ fn generate(args: &Args) -> Result<()> {
         .chooser()
         .context("seeding the file size sampler")?;
 
-    builder
+    builder = builder
         .format(args.format.into())
         .file_sizes(sizes)
-        .jobs(args.jobs)
-        .build()
-        .generate()?;
+        .jobs(args.jobs);
+    if progress.enabled() {
+        let progress = Arc::clone(progress);
+        builder = builder.progress(move |snapshot| progress.update(snapshot));
+    }
+    builder.build().generate()?;
     Ok(())
 }

--- a/crates/caf/src/main.rs
+++ b/crates/caf/src/main.rs
@@ -13,6 +13,7 @@
 
 mod corrupt;
 mod generate;
+mod progress;
 mod render;
 mod show;
 mod style;

--- a/crates/caf/src/progress.rs
+++ b/crates/caf/src/progress.rs
@@ -1,0 +1,337 @@
+//! Live terminal progress rendering for long-running commands.
+
+use std::env;
+use std::io::{self, IsTerminal as _, Write as _};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::{Duration, Instant};
+
+use caf_store::OperationProgress;
+
+use crate::style::Style;
+
+/// Width of the progress track in terminal columns.
+const BAR_WIDTH: usize = 16;
+/// Maximum refresh rate; worker callbacks may arrive much more frequently.
+const DRAW_INTERVAL: Duration = Duration::from_millis(80);
+const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/// Which known limit best describes overall completion.
+#[derive(Clone, Copy, Debug)]
+pub enum Basis {
+    /// Verification knows all file sizes, so bytes prevent one large file
+    /// from hiding behind many completed small files.
+    Bytes,
+    /// Generation stops when any configured limit is reached.
+    AnyLimit,
+}
+
+/// One in-place terminal progress line, safe to update from worker threads.
+#[derive(Debug)]
+pub struct ProgressBar {
+    label: &'static str,
+    basis: Basis,
+    enabled: bool,
+    style: Style,
+    state: Mutex<State>,
+}
+
+#[derive(Debug)]
+struct State {
+    started: Instant,
+    last_draw: Option<Instant>,
+    latest: Option<OperationProgress>,
+    visible: bool,
+}
+
+impl ProgressBar {
+    /// Creates a progress line for standard error. Rendering is enabled only
+    /// for a capable terminal, never for redirected or captured output.
+    pub fn new(label: &'static str, basis: Basis) -> Arc<Self> {
+        Arc::new(Self {
+            label,
+            basis,
+            enabled: terminal_allowed(),
+            style: Style::for_stderr(),
+            state: Mutex::new(State {
+                started: Instant::now(),
+                last_draw: None,
+                latest: None,
+                visible: false,
+            }),
+        })
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Records a worker snapshot and redraws at a bounded rate.
+    pub fn update(&self, progress: OperationProgress) {
+        if !self.enabled {
+            return;
+        }
+        let now = Instant::now();
+        let mut state = self.lock();
+        state.latest = Some(progress);
+        let due = state
+            .last_draw
+            .is_none_or(|last| now.duration_since(last) >= DRAW_INTERVAL);
+        if due {
+            self.draw(&mut state, now, false, true);
+        }
+    }
+
+    /// Leaves a final 100% summary line in the terminal history.
+    pub fn finish(&self, success: bool) {
+        if !self.enabled {
+            return;
+        }
+        let now = Instant::now();
+        let mut state = self.lock();
+        if state.latest.is_some() {
+            self.draw(&mut state, now, true, success);
+            let _ignored = writeln!(io::stderr().lock());
+            state.visible = false;
+        }
+    }
+
+    /// Removes the active line before an operation error is printed.
+    pub fn clear(&self) {
+        if !self.enabled {
+            return;
+        }
+        let mut state = self.lock();
+        if state.visible {
+            let _ignored = write!(io::stderr().lock(), "\r\x1b[2K");
+            state.visible = false;
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "the completion ratio is clamped to 0..=1 before conversion"
+    )]
+    fn draw(&self, state: &mut State, now: Instant, finished: bool, success: bool) {
+        let Some(progress) = state.latest else {
+            return;
+        };
+        let elapsed = now.duration_since(state.started);
+        let ratio = if finished {
+            1.0
+        } else {
+            completion_ratio(progress, self.basis)
+        };
+        let percent = (ratio * 100.0).floor() as u8;
+        let marker = if finished && success {
+            self.style.green("✓")
+        } else if finished {
+            self.style.red("✗")
+        } else {
+            let frame = (elapsed.as_millis() / DRAW_INTERVAL.as_millis()) as usize % SPINNER.len();
+            self.style.cyan(SPINNER[frame])
+        };
+        let bar = progress_track(ratio);
+        let bar = if finished && success {
+            self.style.green(bar)
+        } else if finished {
+            self.style.red(bar)
+        } else {
+            self.style.cyan(bar)
+        };
+        let details = details(progress, ratio, elapsed, finished);
+        let mut err = io::stderr().lock();
+        // Autowrap is off (DECAWM) while the line is written: on a
+        // narrow terminal the details clip at the right edge instead of
+        // wrapping, and a wrapped line would leave its first physical
+        // row behind, since `\x1b[2K` on the next redraw clears only
+        // the row the cursor is on.
+        let _ignored = write!(
+            err,
+            "\x1b[?7l\r\x1b[2K{marker} {:<8} {bar} {percent:>3}%  {details}\x1b[?7h",
+            self.label
+        );
+        let _ignored = err.flush();
+        state.last_draw = Some(now);
+        state.visible = true;
+    }
+}
+
+fn terminal_allowed() -> bool {
+    io::stderr().is_terminal() && env::var_os("TERM").is_none_or(|term| term != "dumb")
+}
+
+/// Highest ratio an unfinished byte-based operation displays.
+///
+/// Verification bytes can complete before the last files do: corruption
+/// analysis rereads a mismatched file after its bytes were counted by
+/// the initial hash pass. A full bar would look done while analysis
+/// still runs, so an incomplete file count holds the display just short.
+const MAX_ACTIVE_RATIO: f64 = 0.99;
+
+fn completion_ratio(progress: OperationProgress, basis: Basis) -> f64 {
+    let bytes = fraction(progress.bytes_completed(), progress.total_bytes());
+    let files = fraction(progress.files_completed(), progress.total_files());
+    let ratio = match basis {
+        Basis::Bytes => {
+            let ratio = bytes.or(files);
+            if files.is_some_and(|files| files < 1.0) {
+                ratio.map(|ratio| ratio.min(MAX_ACTIVE_RATIO))
+            } else {
+                ratio
+            }
+        }
+        Basis::AnyLimit => match (bytes, files) {
+            (Some(bytes), Some(files)) => Some(bytes.max(files)),
+            (bytes, files) => bytes.or(files),
+        },
+    };
+    ratio.unwrap_or(0.0).clamp(0.0, 1.0)
+}
+
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "terminal percentages and ETAs need only display precision"
+)]
+fn fraction(completed: u64, total: Option<u64>) -> Option<f64> {
+    total.map(|total| {
+        if total == 0 {
+            1.0
+        } else {
+            completed as f64 / total as f64
+        }
+    })
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    reason = "the clamped ratio maps into a fixed 16-column integer track"
+)]
+fn progress_track(ratio: f64) -> String {
+    let completed = ((BAR_WIDTH as f64 * ratio).floor() as usize).min(BAR_WIDTH);
+    if completed == BAR_WIDTH {
+        return "━".repeat(BAR_WIDTH);
+    }
+    if completed == 0 {
+        return "─".repeat(BAR_WIDTH);
+    }
+    format!(
+        "{}╺{}",
+        "━".repeat(completed.saturating_sub(1)),
+        "─".repeat(BAR_WIDTH - completed)
+    )
+}
+
+fn details(progress: OperationProgress, ratio: f64, elapsed: Duration, finished: bool) -> String {
+    let mut parts = Vec::with_capacity(4);
+    parts.push(match progress.total_bytes() {
+        Some(total) => format!(
+            "{} / {}",
+            human_bytes(progress.bytes_completed()),
+            human_bytes(total)
+        ),
+        None => format!("{} processed", human_bytes(progress.bytes_completed())),
+    });
+    parts.push(match progress.total_files() {
+        Some(total) => format!("{} / {} files", progress.files_completed(), total),
+        None => format!("{} files", progress.files_completed()),
+    });
+
+    let seconds = elapsed.as_secs_f64();
+    if seconds >= 0.1 && progress.bytes_completed() > 0 {
+        let rate = (u128::from(progress.bytes_completed()) * 1_000_000_000 / elapsed.as_nanos())
+            .min(u128::from(u64::MAX));
+        let rate = u64::try_from(rate).expect("the rate was clamped to the u64 range");
+        parts.push(format!("{}/s", human_bytes(rate)));
+    }
+    if finished {
+        parts.push(format_duration(elapsed));
+    } else if ratio > 0.0 && ratio < 1.0 && seconds >= 0.1 {
+        let remaining = elapsed.mul_f64((1.0 - ratio) / ratio);
+        let remaining = if remaining < Duration::from_secs(1) {
+            "<1s".to_owned()
+        } else {
+            format_duration(remaining)
+        };
+        parts.push(format!("ETA {remaining}"));
+    } else {
+        parts.push("ETA —".to_owned());
+    }
+    parts.join("  ")
+}
+
+fn human_bytes(bytes: u64) -> String {
+    const UNITS: [(&str, u64); 5] = [
+        ("TiB", 1 << 40),
+        ("GiB", 1 << 30),
+        ("MiB", 1 << 20),
+        ("KiB", 1 << 10),
+        ("B", 1),
+    ];
+    let (unit, divisor) = UNITS
+        .into_iter()
+        .find(|(_unit, divisor)| bytes >= *divisor)
+        .unwrap_or(("B", 1));
+    if divisor == 1 {
+        return format!("{bytes} {unit}");
+    }
+    let whole = bytes / divisor;
+    if whole >= 100 {
+        format!("{whole} {unit}")
+    } else if whole >= 10 {
+        let tenths = (u128::from(bytes) * 10 / u128::from(divisor)) % 10;
+        format!("{whole}.{tenths} {unit}")
+    } else {
+        let hundredths = (u128::from(bytes) * 100 / u128::from(divisor)) % 100;
+        format!("{whole}.{hundredths:02} {unit}")
+    }
+}
+
+fn format_duration(duration: Duration) -> String {
+    if duration < Duration::from_secs(1) {
+        return "<1s".to_owned();
+    }
+    let seconds = duration.as_secs();
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 60 * 60 {
+        format!("{}m {:02}s", seconds / 60, seconds % 60)
+    } else {
+        format!("{}h {:02}m", seconds / 3600, (seconds / 60) % 60)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{format_duration, human_bytes, progress_track};
+
+    #[test]
+    fn byte_units_stay_compact() {
+        assert_eq!(human_bytes(0), "0 B");
+        assert_eq!(human_bytes(1536), "1.50 KiB");
+        assert_eq!(human_bytes(64 * 1024 * 1024), "64.0 MiB");
+    }
+
+    #[test]
+    fn duration_uses_at_most_two_units() {
+        assert_eq!(format_duration(Duration::from_millis(900)), "<1s");
+        assert_eq!(format_duration(Duration::from_secs(9)), "9s");
+        assert_eq!(format_duration(Duration::from_secs(125)), "2m 05s");
+        assert_eq!(format_duration(Duration::from_secs(7325)), "2h 02m");
+    }
+
+    #[test]
+    fn progress_track_has_a_fixed_width() {
+        for ratio in [0.0, 0.01, 0.5, 0.99, 1.0] {
+            assert_eq!(progress_track(ratio).chars().count(), 16);
+        }
+    }
+}

--- a/crates/caf/src/style.rs
+++ b/crates/caf/src/style.rs
@@ -57,6 +57,11 @@ impl Style {
         self.paint("32", text)
     }
 
+    /// Cyan, for an active progress indicator.
+    pub fn cyan(self, text: impl Display) -> String {
+        self.paint("36", text)
+    }
+
     /// Red, for failure markers (`✗`, `no`) and corruption bars.
     pub fn red(self, text: impl Display) -> String {
         self.paint("31", text)

--- a/crates/caf/src/verify.rs
+++ b/crates/caf/src/verify.rs
@@ -8,10 +8,12 @@
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
 use caf_store::{DEFAULT_ANALYSIS_CHUNK_SIZE, Verifier, default_jobs};
 
+use crate::progress::{Basis, ProgressBar};
 use crate::style::Style;
 use crate::util::{StoreRoot, commas};
 use crate::{EXIT_FAILURE, render};
@@ -85,10 +87,12 @@ fn parse_positive(value: &str) -> Result<NonZeroUsize> {
 pub fn run(args: &Args) -> ExitCode {
     let out = Style::for_stdout();
     let err = Style::for_stderr();
+    let progress = ProgressBar::new("Verify", Basis::Bytes);
 
-    let failed = match verify(args, out, err) {
+    let failed = match verify(args, out, err, &progress) {
         Ok(failed) => failed,
         Err(error) => {
+            progress.clear();
             // A store-level failure (not a store, unreadable file,
             // pathological nesting) fails verification; the not-a-store
             // message is the error's Display.
@@ -108,7 +112,7 @@ pub fn run(args: &Args) -> ExitCode {
 
 /// Verifies the store `args` names, rendering the report, and returns
 /// whether verification failed.
-fn verify(args: &Args, out: Style, err: Style) -> Result<bool> {
+fn verify(args: &Args, out: Style, err: Style, progress: &Arc<ProgressBar>) -> Result<bool> {
     let directory = StoreRoot::from(args.directory.as_deref()).resolve()?;
 
     println!(
@@ -123,10 +127,15 @@ fn verify(args: &Args, out: Style, err: Style) -> Result<bool> {
         ))
     );
 
-    let report = Verifier::new(&directory)
+    let mut verifier = Verifier::new(&directory)
         .analysis_chunk_size(args.chunk_size)
-        .jobs(args.jobs)
-        .verify()?;
+        .jobs(args.jobs);
+    if progress.enabled() {
+        let progress = Arc::clone(progress);
+        verifier = verifier.progress(move |snapshot| progress.update(snapshot));
+    }
+    let report = verifier.verify()?;
+    progress.finish(report.success());
     render::diagnostics(report.diagnostics(), err);
     render::error_analysis(&report, out);
     Ok(!report.success())

--- a/crates/caf/tests/cli.rs
+++ b/crates/caf/tests/cli.rs
@@ -323,6 +323,15 @@ fn gen_default_is_100_files_of_4096_bytes() {
 }
 
 #[test]
+fn captured_generation_success_remains_silent() {
+    let dir = tempdir();
+    let output = generate(dir.path(), &["--max-files", "1"]);
+    assert_eq!(code(&output), 0);
+    assert!(stdout(&output).is_empty(), "{}", stdout(&output));
+    assert!(stderr(&output).is_empty(), "{}", stderr(&output));
+}
+
+#[test]
 fn file_size_suffix_grammar() {
     for (spec, expected) in [
         ("8192", 8192),


### PR DESCRIPTION
Large stores can take a long time to process without any indication that work is advancing or when it might finish.

* Add thread-safe progress callbacks with monotonic byte and file snapshots to the generation and verification APIs
* Track serial and parallel I/O without changing generated data or verification results
* Render terminal-only progress with throughput and estimated time remaining while preserving silent redirected generation